### PR TITLE
runtime optim

### DIFF
--- a/.github/workflows/rust_tests.yml
+++ b/.github/workflows/rust_tests.yml
@@ -44,7 +44,7 @@ jobs:
       run: ./scripts/init.sh
 
     - name: Run tests
-      run: cargo test --all
+      run: cargo test --all-targets --all-features --workspace
 
   fmt:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,7 +1947,6 @@ dependencies = [
  "governance-os-primitives",
  "pallet-aura",
  "pallet-grandpa",
- "pallet-indices",
  "pallet-randomness-collective-flip",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -3715,24 +3714,6 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-indices"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d234bf46076a835b473a987f089299ffa3efd961a92b5be9384cc280fcc8c8f"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "serde",
- "sp-core",
- "sp-io",
- "sp-keyring",
- "sp-runtime",
  "sp-std",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,7 +1911,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "governance-os-support",
- "pallet-balances",
  "parity-scale-codec",
  "serde",
  "sp-core",
@@ -3658,21 +3657,6 @@ dependencies = [
  "parity-scale-codec",
  "sp-authorship",
  "sp-inherents",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-balances"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56bf116724c3adb7eee6ae49adfc28d3d38d9d34bbfdcc009497120256309a37"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "serde",
  "sp-runtime",
  "sp-std",
 ]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -17,8 +17,8 @@
 use governance_os_pallet_tokens::CurrencyDetails;
 use governance_os_primitives::{AccountId, CurrencyId, Signature};
 use governance_os_runtime::{
-    AuraConfig, AuraId, GenesisConfig, GrandpaConfig, GrandpaId, IndicesConfig, NativeCurrencyId,
-    SystemConfig, TokensConfig, WASM_BINARY,
+    AuraConfig, AuraId, GenesisConfig, GrandpaConfig, GrandpaId, NativeCurrencyId, SystemConfig,
+    TokensConfig, WASM_BINARY,
 };
 use sc_service::ChainType;
 use sp_core::{sr25519, Pair, Public};
@@ -78,7 +78,6 @@ fn testnet_genesis(
                 .map(|x| (x.1.clone(), 1))
                 .collect(),
         }),
-        pallet_indices: Some(IndicesConfig { indices: vec![] }),
         governance_os_pallet_tokens: Some(TokensConfig {
             endowed_accounts: endowed_accounts
                 .iter()

--- a/pallets/tokens/Cargo.toml
+++ b/pallets/tokens/Cargo.toml
@@ -19,7 +19,6 @@ frame-benchmarking = { default-features = false, version = '2.0.0', optional = t
 frame-support = { default-features = false, version = '2.0.0' }
 frame-system = { default-features = false, version = '2.0.0' }
 governance-os-support = { default-features = false, path = '../../support' }
-pallet-balances = { default-features = false, version = '2.0.0' }
 serde = { version = "1.0.116", optional = true }
 sp-runtime = { default-features = false, version = '2.0.0' }
 sp-std = { default-features = false, version = "2.0.0" }
@@ -35,7 +34,6 @@ std = [
     'frame-support/std',
     'frame-system/std',
     'governance-os-support/std',
-    'pallet-balances/std',
     'serde',
     'sp-runtime/std',
     'sp-std/std',

--- a/pallets/tokens/src/account_data.rs
+++ b/pallets/tokens/src/account_data.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use codec::{Decode, Encode};
+use sp_runtime::RuntimeDebug;
+use sp_std::collections::btree_map::BTreeMap;
+
+/// All balance information for an account and an associated currency.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+pub struct AccountCurrencyData<Balance> {
+    /// Non-reserved part of the balance. There may still be restrictions on this, but it is the
+    /// total pool what may in principle be transferred, reserved and used for tipping.
+    ///
+    /// This is the only balance that matters in terms of most operations on tokens. It
+    /// alone is used to determine the balance when in the contract execution environment.
+    pub free: Balance,
+    /// Balance which is reserved and may not be used at all.
+    ///
+    /// This can still get slashed, but gets slashed last of all.
+    ///
+    /// This balance is a 'reserve' balance that other subsystems use in order to set aside tokens
+    /// that are still 'owned' by the account holder, but which are suspendable.
+    pub reserved: Balance,
+}
+
+/// All balance and currency informations for an account.
+pub type AccountData<CurrencyId, Balance> = BTreeMap<CurrencyId, AccountCurrencyData<Balance>>;

--- a/pallets/tokens/src/account_data.rs
+++ b/pallets/tokens/src/account_data.rs
@@ -15,7 +15,7 @@
  */
 
 use codec::{Decode, Encode};
-use sp_runtime::RuntimeDebug;
+use sp_runtime::{traits::Saturating, RuntimeDebug};
 use sp_std::collections::btree_map::BTreeMap;
 
 /// All balance information for an account and an associated currency.
@@ -34,6 +34,12 @@ pub struct AccountCurrencyData<Balance> {
     /// This balance is a 'reserve' balance that other subsystems use in order to set aside tokens
     /// that are still 'owned' by the account holder, but which are suspendable.
     pub reserved: Balance,
+}
+impl<Balance: Saturating + Copy> AccountCurrencyData<Balance> {
+    /// Computes and return the total balance, including reserved funds.
+    pub fn total(&self) -> Balance {
+        self.free.saturating_add(self.reserved)
+    }
 }
 
 /// All balance and currency informations for an account.

--- a/pallets/tokens/src/adapter.rs
+++ b/pallets/tokens/src/adapter.rs
@@ -202,7 +202,7 @@ where
         amount: Self::Balance,
     ) -> (Self::NegativeImbalance, Self::Balance) {
         let mut slashed = amount;
-        <Balances<Pallet>>::mutate(who, GetCurrencyId::get(), |data| {
+        Module::<Pallet>::mutate_currency_account(GetCurrencyId::get(), who, |data| {
             slashed = data.reserved.min(amount);
             // Slashed will be at most equal to data.reserved, no underflow
             data.reserved -= slashed;

--- a/pallets/tokens/src/currencies.rs
+++ b/pallets/tokens/src/currencies.rs
@@ -99,15 +99,20 @@ impl<T: Trait> Currencies<T::AccountId> for Module<T> {
     ) -> DispatchResult {
         Self::ensure_can_withdraw(currency_id, source, amount)?;
 
-        let source_new_balance = Self::free_balance(currency_id, source)
-            .checked_sub(&amount)
-            .ok_or(Error::<T>::BalanceTooLow)?;
-        let dest_new_balance = Self::free_balance(currency_id, dest)
-            .checked_add(&amount)
-            .ok_or(Error::<T>::BalanceOverflow)?;
-
-        Self::set_free_balance(currency_id, source, source_new_balance);
-        Self::set_free_balance(currency_id, dest, dest_new_balance);
+        Self::set_free_balance(
+            currency_id,
+            source,
+            Self::free_balance(currency_id, source)
+                .checked_sub(&amount)
+                .ok_or(Error::<T>::BalanceTooLow)?,
+        );
+        Self::set_free_balance(
+            currency_id,
+            dest,
+            Self::free_balance(currency_id, dest)
+                .checked_add(&amount)
+                .ok_or(Error::<T>::BalanceOverflow)?,
+        );
 
         Self::deposit_event(RawEvent::CurrencyTransferred(
             currency_id,

--- a/pallets/tokens/src/default_weights.rs
+++ b/pallets/tokens/src/default_weights.rs
@@ -20,17 +20,17 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 impl crate::WeightInfo for () {
     fn create() -> Weight {
-        (62_000_000 as Weight)
+        (60_000_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn mint() -> Weight {
-        (91_000_000 as Weight)
+        (108_000_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn burn() -> Weight {
-        (98_000_000 as Weight)
+        (112_000_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
@@ -40,8 +40,8 @@ impl crate::WeightInfo for () {
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn transfer() -> Weight {
-        (107_000_000 as Weight)
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
+        (133_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(5 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
     }
 }

--- a/pallets/tokens/src/tests/currencies.rs
+++ b/pallets/tokens/src/tests/currencies.rs
@@ -39,6 +39,24 @@ fn transfer_should_work() {
 }
 
 #[test]
+fn transfer_to_self_is_noop() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as Currencies<AccountId>>::transfer(
+                TEST_TOKEN_ID,
+                &ALICE,
+                &ALICE,
+                50
+            ));
+            assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 100);
+            assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &BOB), 100);
+            assert_eq!(Tokens::total_issuance(TEST_TOKEN_ID), 200);
+        })
+}
+
+#[test]
 fn mint_should_work() {
     ExtBuilder::default().build().execute_with(|| {
         assert_ok!(<Tokens as Currencies<AccountId>>::mint(

--- a/pallets/tokens/src/tests/misc.rs
+++ b/pallets/tokens/src/tests/misc.rs
@@ -42,3 +42,23 @@ fn kill_currency_if_balance_down_to_zero() {
             );
         })
 }
+
+#[test]
+fn kill_account_if_all_balances_down_to_zero() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as Currencies<AccountId>>::transfer(
+                TEST_TOKEN_ID,
+                &ALICE,
+                &BOB,
+                Tokens::free_balance(TEST_TOKEN_ID, &ALICE),
+            ));
+
+            // We can still view the balance(s)
+            assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 0);
+            // Deleted the entry
+            assert_eq!(<Account<Test>>::contains_key(&ALICE), false);
+        })
+}

--- a/pallets/tokens/src/tests/misc.rs
+++ b/pallets/tokens/src/tests/misc.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::mock::*;
+use frame_support::{assert_ok, StorageMap};
+use frame_system::Account;
+
+#[test]
+fn kill_currency_if_balance_down_to_zero() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as Currencies<AccountId>>::transfer(
+                TEST_TOKEN_ID,
+                &ALICE,
+                &BOB,
+                Tokens::free_balance(TEST_TOKEN_ID, &ALICE),
+            ));
+
+            // We can still view the balance
+            assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, &ALICE), 0);
+            // Deleted the entry
+            assert_eq!(
+                <Account<Test>>::get(&ALICE)
+                    .data
+                    .contains_key(&TEST_TOKEN_ID),
+                false
+            );
+        })
+}

--- a/pallets/tokens/src/tests/mock.rs
+++ b/pallets/tokens/src/tests/mock.rs
@@ -64,7 +64,7 @@ impl system::Trait for Test {
     type AvailableBlockRatio = AvailableBlockRatio;
     type Version = ();
     type PalletInfo = ();
-    type AccountData = ();
+    type AccountData = crate::AccountData<CurrencyId, Balance>;
     type OnNewAccount = ();
     type OnKilledAccount = ();
     type SystemWeightInfo = ();
@@ -75,6 +75,7 @@ impl Trait for Test {
     type CurrencyId = CurrencyId;
     type Balance = Balance;
     type WeightInfo = ();
+    type AccountStore = System;
 }
 
 parameter_types! {

--- a/pallets/tokens/src/tests/mod.rs
+++ b/pallets/tokens/src/tests/mod.rs
@@ -18,4 +18,5 @@ pub mod adapter;
 pub mod currencies;
 pub mod dispatchable;
 pub mod genesis;
+pub mod misc;
 pub mod mock;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -50,9 +50,6 @@ pub type Signature = MultiSignature;
 /// to the public key of our transaction signing scheme.
 pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 
-/// The type for looking up accounts. We don't expect more than 4 billion of them.
-pub type AccountIndex = u32;
-
 /// Balance of an account.
 pub type Balance = u128;
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -81,6 +81,7 @@ runtime-benchmarks = [
     'frame-system-benchmarking',
     'frame-system/runtime-benchmarks',
     'governance-os-pallet-tokens/runtime-benchmarks',
+    'pallet-grandpa/runtime-benchmarks',
     'pallet-timestamp/runtime-benchmarks',
     'sp-runtime/runtime-benchmarks',
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -28,7 +28,6 @@ governance-os-pallet-tokens = { default-features = false, path = '../pallets/tok
 governance-os-primitives = { default-features = false, path = '../primitives' }
 pallet-aura = { version = '2.0.0', default-features = false }
 pallet-grandpa = { version = '2.0.0', default-features = false }
-pallet-indices = { version = '2.0.0', default-features = false }
 pallet-randomness-collective-flip = { version = '2.0.0', default-features = false }
 pallet-timestamp = { version = '2.0.0', default-features = false }
 pallet-transaction-payment = { version = '2.0.0', default-features = false }
@@ -59,7 +58,6 @@ std = [
     'governance-os-primitives/std',
     'pallet-aura/std',
     'pallet-grandpa/std',
-    'pallet-indices/std',
     'pallet-randomness-collective-flip/std',
     'pallet-timestamp/std',
     'pallet-transaction-payment/std',
@@ -83,7 +81,6 @@ runtime-benchmarks = [
     'frame-system-benchmarking',
     'frame-system/runtime-benchmarks',
     'governance-os-pallet-tokens/runtime-benchmarks',
-    'pallet-indices/runtime-benchmarks',
     'pallet-timestamp/runtime-benchmarks',
     'sp-runtime/runtime-benchmarks',
 ]

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -17,17 +17,17 @@
 //! A set of constant values used in the runtime.
 
 /// Money matters.
-pub mod currency {
-    use governance_os_primitives::Balance;
+// pub mod currency {
+// use governance_os_primitives::Balance;
 
-    pub const MILLICENTS: Balance = 1_000_000_000;
-    pub const CENTS: Balance = 1_000 * MILLICENTS; // assume this is worth about a cent.
-    pub const DOLLARS: Balance = 100 * CENTS;
+// pub const MILLICENTS: Balance = 1_000_000_000;
+// pub const CENTS: Balance = 1_000 * MILLICENTS; // assume this is worth about a cent.
+// pub const DOLLARS: Balance = 100 * CENTS;
 
-    // pub const fn deposit(items: u32, bytes: u32) -> Balance {
-    //     items as Balance * 15 * CENTS + (bytes as Balance) * 6 * CENTS
-    // }
-}
+// pub const fn deposit(items: u32, bytes: u32) -> Balance {
+//     items as Balance * 15 * CENTS + (bytes as Balance) * 6 * CENTS
+// }
+// }
 
 /// Time.
 pub mod time {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -47,6 +47,7 @@ mod pallets_consensus;
 mod pallets_core;
 mod pallets_economics;
 mod version;
+mod weights;
 
 pub use pallets_consensus::{AuraId, GrandpaId, SessionKeys};
 pub use pallets_economics::{NativeCurrency, NativeCurrencyId};

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -35,7 +35,7 @@ use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
     generic,
-    traits::{BlakeTwo256, Block as BlockT, NumberFor, StaticLookup},
+    traits::{BlakeTwo256, Block as BlockT, NumberFor},
     transaction_validity::{TransactionSource, TransactionValidity},
     ApplyExtrinsicResult,
 };
@@ -63,7 +63,6 @@ construct_runtime!(
     {
         // Core
         System: frame_system::{Module, Call, Config, Storage, Event<T>},
-        Indices: pallet_indices::{Module, Call, Storage, Config<T>, Event<T>},
         RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
 
         // Consensus
@@ -78,7 +77,7 @@ construct_runtime!(
 );
 
 /// The address format for describing accounts.
-pub type Address = <Indices as StaticLookup>::Source;
+pub type Address = AccountId;
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type as expected by this runtime.
@@ -246,7 +245,6 @@ impl_runtime_apis! {
 
             add_benchmark!(params, batches, frame_system, SystemBench::<Runtime>);
             add_benchmark!(params, batches, governance_os_pallet_tokens, Tokens);
-            add_benchmark!(params, batches, pallet_indices, Indices);
             add_benchmark!(params, batches, pallet_timestamp, Timestamp);
 
             if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -245,6 +245,7 @@ impl_runtime_apis! {
 
             add_benchmark!(params, batches, frame_system, SystemBench::<Runtime>);
             add_benchmark!(params, batches, governance_os_pallet_tokens, Tokens);
+            add_benchmark!(params, batches, pallet_grandpa, Grandpa);
             add_benchmark!(params, batches, pallet_timestamp, Timestamp);
 
             if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }

--- a/runtime/src/pallets_consensus.rs
+++ b/runtime/src/pallets_consensus.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::{constants::time, Aura, Call, Event, Grandpa, Runtime};
+use crate::{constants::time, weights, Aura, Call, Event, Grandpa, Runtime};
 use frame_support::{parameter_types, traits::KeyOwnerProofSystem};
 use governance_os_primitives::Moment;
 pub use pallet_grandpa::AuthorityId as GrandpaId;
@@ -45,7 +45,7 @@ impl pallet_grandpa::Trait for Runtime {
         GrandpaId,
     )>>::IdentificationTuple;
     type HandleEquivocation = ();
-    type WeightInfo = ();
+    type WeightInfo = weights::pallet_grandpa::WeightInfo;
 }
 
 parameter_types! {
@@ -57,5 +57,5 @@ impl pallet_timestamp::Trait for Runtime {
     type Moment = Moment;
     type OnTimestampSet = Aura;
     type MinimumPeriod = MinimumPeriod;
-    type WeightInfo = ();
+    type WeightInfo = weights::pallet_timestamp::WeightInfo;
 }

--- a/runtime/src/pallets_core.rs
+++ b/runtime/src/pallets_core.rs
@@ -22,7 +22,7 @@ use frame_support::{
         Weight,
     },
 };
-use governance_os_primitives::{AccountId, Balance, BlockNumber, Hash, Index};
+use governance_os_primitives::{AccountId, Balance, BlockNumber, CurrencyId, Hash, Index};
 use sp_runtime::{
     generic,
     traits::{BlakeTwo256, IdentityLookup, Saturating},
@@ -70,7 +70,7 @@ impl frame_system::Trait for Runtime {
     type AvailableBlockRatio = AvailableBlockRatio;
     type Version = Version;
     type PalletInfo = PalletInfo;
-    type AccountData = governance_os_pallet_tokens::AccountData<Balance>;
+    type AccountData = governance_os_pallet_tokens::AccountData<CurrencyId, Balance>;
     type OnNewAccount = ();
     type OnKilledAccount = ();
     type SystemWeightInfo = ();

--- a/runtime/src/pallets_core.rs
+++ b/runtime/src/pallets_core.rs
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-use crate::{
-    constants::currency::DOLLARS, Call, Event, Indices, NativeCurrency, Origin, PalletInfo,
-    Runtime, VERSION,
-};
+use crate::{Call, Event, Origin, PalletInfo, Runtime, VERSION};
 use frame_support::{
     parameter_types,
     weights::{
@@ -25,10 +22,10 @@ use frame_support::{
         Weight,
     },
 };
-use governance_os_primitives::{AccountId, AccountIndex, Balance, BlockNumber, Hash, Index};
+use governance_os_primitives::{AccountId, Balance, BlockNumber, Hash, Index};
 use sp_runtime::{
     generic,
-    traits::{BlakeTwo256, Saturating},
+    traits::{BlakeTwo256, IdentityLookup, Saturating},
     Perbill,
 };
 use sp_version::RuntimeVersion;
@@ -60,7 +57,7 @@ impl frame_system::Trait for Runtime {
     type Hash = Hash;
     type Hashing = BlakeTwo256;
     type AccountId = AccountId;
-    type Lookup = Indices;
+    type Lookup = IdentityLookup<AccountId>;
     type Header = generic::Header<BlockNumber, BlakeTwo256>;
     type Event = Event;
     type BlockHashCount = BlockHashCount;
@@ -77,16 +74,4 @@ impl frame_system::Trait for Runtime {
     type OnNewAccount = ();
     type OnKilledAccount = ();
     type SystemWeightInfo = ();
-}
-
-parameter_types! {
-    pub const IndexDeposit: Balance = 1 * DOLLARS;
-}
-
-impl pallet_indices::Trait for Runtime {
-    type AccountIndex = AccountIndex;
-    type Currency = NativeCurrency;
-    type Deposit = IndexDeposit;
-    type Event = Event;
-    type WeightInfo = ();
 }

--- a/runtime/src/pallets_core.rs
+++ b/runtime/src/pallets_core.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::{Call, Event, Origin, PalletInfo, Runtime, VERSION};
+use crate::{weights, Call, Event, Origin, PalletInfo, Runtime, VERSION};
 use frame_support::{
     parameter_types,
     weights::{
@@ -73,5 +73,5 @@ impl frame_system::Trait for Runtime {
     type AccountData = governance_os_pallet_tokens::AccountData<CurrencyId, Balance>;
     type OnNewAccount = ();
     type OnKilledAccount = ();
-    type SystemWeightInfo = ();
+    type SystemWeightInfo = weights::frame_system::WeightInfo;
 }

--- a/runtime/src/pallets_economics.rs
+++ b/runtime/src/pallets_economics.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::{Event, Runtime};
+use crate::{Event, Runtime, System};
 use frame_support::{parameter_types, weights::IdentityFee};
 use governance_os_pallet_tokens::NativeCurrencyAdapter;
 use governance_os_primitives::{Balance, CurrencyId};
@@ -24,6 +24,7 @@ impl governance_os_pallet_tokens::Trait for Runtime {
     type Balance = Balance;
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
+    type AccountStore = System;
 }
 
 parameter_types! {

--- a/runtime/src/weights/frame_system.rs
+++ b/runtime/src/weights/frame_system.rs
@@ -20,37 +20,37 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 pub struct WeightInfo;
 impl frame_system::WeightInfo for WeightInfo {
-	// WARNING! Some components were not used: ["b"]
-	fn remark() -> Weight {
-		2_106_000 as Weight
-	}
-	fn set_heap_pages() -> Weight {
-		(5_000_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
-	}
-	// WARNING! Some components were not used: ["d"]
-	fn set_changes_trie_config() -> Weight {
-		(14_307_000 as Weight)
-			.saturating_add(DbWeight::get().reads(1 as Weight))
-			.saturating_add(DbWeight::get().writes(2 as Weight))
-	}
-	fn set_storage(i: u32) -> Weight {
-		(0 as Weight)
-			.saturating_add((1_599_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
-	}
-	fn kill_storage(i: u32) -> Weight {
-		(4_553_000 as Weight)
-			.saturating_add((1_004_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
-	}
-	fn kill_prefix(p: u32) -> Weight {
-		(10_358_000 as Weight)
-			.saturating_add((1_938_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(p as Weight)))
-	}
-	fn suicide() -> Weight {
-		(71_000_000 as Weight)
-			.saturating_add(DbWeight::get().reads(4 as Weight))
-			.saturating_add(DbWeight::get().writes(2 as Weight))
-	}
+    // WARNING! Some components were not used: ["b"]
+    fn remark() -> Weight {
+        2_106_000 as Weight
+    }
+    fn set_heap_pages() -> Weight {
+        (5_000_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    // WARNING! Some components were not used: ["d"]
+    fn set_changes_trie_config() -> Weight {
+        (14_307_000 as Weight)
+            .saturating_add(DbWeight::get().reads(1 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn set_storage(i: u32) -> Weight {
+        (0 as Weight)
+            .saturating_add((1_599_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+    }
+    fn kill_storage(i: u32) -> Weight {
+        (4_553_000 as Weight)
+            .saturating_add((1_004_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+    }
+    fn kill_prefix(p: u32) -> Weight {
+        (10_358_000 as Weight)
+            .saturating_add((1_938_000 as Weight).saturating_mul(p as Weight))
+            .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(p as Weight)))
+    }
+    fn suicide() -> Weight {
+        (71_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
 }

--- a/runtime/src/weights/frame_system.rs
+++ b/runtime/src/weights/frame_system.rs
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
+
+use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
+
+pub struct WeightInfo;
+impl frame_system::WeightInfo for WeightInfo {
+	// WARNING! Some components were not used: ["b"]
+	fn remark() -> Weight {
+		2_106_000 as Weight
+	}
+	fn set_heap_pages() -> Weight {
+		(5_000_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	// WARNING! Some components were not used: ["d"]
+	fn set_changes_trie_config() -> Weight {
+		(14_307_000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
+	}
+	fn set_storage(i: u32) -> Weight {
+		(0 as Weight)
+			.saturating_add((1_599_000 as Weight).saturating_mul(i as Weight))
+			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+	}
+	fn kill_storage(i: u32) -> Weight {
+		(4_553_000 as Weight)
+			.saturating_add((1_004_000 as Weight).saturating_mul(i as Weight))
+			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+	}
+	fn kill_prefix(p: u32) -> Weight {
+		(10_358_000 as Weight)
+			.saturating_add((1_938_000 as Weight).saturating_mul(p as Weight))
+			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(p as Weight)))
+	}
+	fn suicide() -> Weight {
+		(71_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(4 as Weight))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
+	}
+}

--- a/runtime/src/weights/mod.rs
+++ b/runtime/src/weights/mod.rs
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod frame_system;
+pub mod pallet_grandpa;
+pub mod pallet_timestamp;

--- a/runtime/src/weights/pallet_grandpa.rs
+++ b/runtime/src/weights/pallet_grandpa.rs
@@ -1,0 +1,21 @@
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
+
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
+
+// Pending on a fix for https://github.com/paritytech/substrate/issues/7383. For now
+// we have to stick to the default implementation.
+pub type WeightInfo = ();
+// pub struct WeightInfo;
+// impl pallet_grandpa::WeightInfo for WeightInfo {
+// 	// WARNING! Some components were not used: ["x"]
+// 	fn check_equivocation_proof() -> Weight {
+// 		(135_500_000 as Weight)
+// 	}
+// 	fn note_stalled() -> Weight {
+// 		(6_000_000 as Weight)
+// 			.saturating_add(DbWeight::get().writes(1 as Weight))
+// 	}
+// }

--- a/runtime/src/weights/pallet_timestamp.rs
+++ b/runtime/src/weights/pallet_timestamp.rs
@@ -3,18 +3,18 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
-use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
+use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 pub struct WeightInfo;
 impl pallet_timestamp::WeightInfo for WeightInfo {
-	// WARNING! Some components were not used: ["t"]
-	fn set() -> Weight {
-		(32_292_000 as Weight)
-			.saturating_add(DbWeight::get().reads(3 as Weight))
-			.saturating_add(DbWeight::get().writes(2 as Weight))
-	}
-	// WARNING! Some components were not used: ["t"]
-	fn on_finalize() -> Weight {
-		(9_632_000 as Weight)
-	}
+    // WARNING! Some components were not used: ["t"]
+    fn set() -> Weight {
+        (32_292_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    // WARNING! Some components were not used: ["t"]
+    fn on_finalize() -> Weight {
+        (9_632_000 as Weight)
+    }
 }

--- a/runtime/src/weights/pallet_timestamp.rs
+++ b/runtime/src/weights/pallet_timestamp.rs
@@ -1,0 +1,20 @@
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
+
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
+
+pub struct WeightInfo;
+impl pallet_timestamp::WeightInfo for WeightInfo {
+	// WARNING! Some components were not used: ["t"]
+	fn set() -> Weight {
+		(32_292_000 as Weight)
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
+	}
+	// WARNING! Some components were not used: ["t"]
+	fn on_finalize() -> Weight {
+		(9_632_000 as Weight)
+	}
+}

--- a/types.json
+++ b/types.json
@@ -1,4 +1,14 @@
 {
+  "AccountCurrencyData": {
+    "free": "Balance",
+    "reserved": "Balance"
+  },
+  "AccountData": "BTreeMap<CurrencyId, AccountCurrencyData<Balance>>",
+  "AccountInfo": {
+    "nonce": "Index",
+    "refcount": "RefCount",
+    "data": "AccountData"
+  },
   "Address": "AccountId",
   "CurrencyDetails": {
     "owner": "AccountId"

--- a/types.json
+++ b/types.json
@@ -1,11 +1,13 @@
 {
+  "Address": "AccountId",
+  "CurrencyDetails": {
+    "owner": "AccountId"
+  },
   "CurrencyId": {
     "_enum": {
       "Native": "Null",
       "Custom": "u32"
     }
   },
-  "CurrencyDetails": {
-    "owner": "AccountId"
-  }
+  "LookupSource": "AccountId"
 }


### PR DESCRIPTION
- removed the indices to have direct lookups instead
- converted accounts storage to follow the composite model of relying on the `System` pallet
- benchmarked other pallets to have the corresponding weights, we have an issue with the ones generate for `Grandpa` though (paritytech/substrate/issues/7383)

Closes #14.
