### PR TITLE
use bylaws to represent inter pallet ACLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,6 +1980,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "governance-os-pallet-bylaws",
  "governance-os-support",
  "parity-scale-codec",
  "serde",
@@ -1994,6 +1995,7 @@ name = "governance-os-primitives"
 version = "0.1.0"
 dependencies = [
  "frame-system",
+ "governance-os-pallet-tokens",
  "governance-os-support",
  "parity-scale-codec",
  "serde",
@@ -2045,6 +2047,7 @@ name = "governance-os-support"
 version = "0.1.0"
 dependencies = [
  "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "sp-runtime",
  "sp-std",

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -61,6 +61,7 @@ fn testnet_genesis(
         NativeCurrencyId::get(),
         CurrencyDetails {
             owner: get_account_id_from_seed::<sr25519::Public>("Alice"),
+            transferable: true,
         },
     )]);
     let chain_roles = roles.unwrap_or(vec![

--- a/pallets/bylaws/src/benchmarking.rs
+++ b/pallets/bylaws/src/benchmarking.rs
@@ -41,7 +41,7 @@ benchmarks! {
 
     revoke_role {
         let (target, target_lookup, role) = prepare_benchmark::<T>();
-       <Module<T> as RoleManager<T::AccountId, T::Role>>::grant_role(Some(&target), role);
+       <Module<T> as RoleManager>::grant_role(Some(&target), role);
     }: _(RawOrigin::Root, Some(target_lookup), role)
     verify {
         assert_eq!(Module::<T>::has_role(&target, role), false);

--- a/pallets/bylaws/src/benchmarking.rs
+++ b/pallets/bylaws/src/benchmarking.rs
@@ -17,7 +17,7 @@
 use crate::*;
 use frame_benchmarking::{account, benchmarks};
 use frame_system::RawOrigin;
-use governance_os_support::benchmarking::SEED;
+use governance_os_support::{acl::RoleManager, benchmarking::SEED};
 use sp_runtime::traits::StaticLookup;
 use sp_std::prelude::*;
 
@@ -41,7 +41,7 @@ benchmarks! {
 
     revoke_role {
         let (target, target_lookup, role) = prepare_benchmark::<T>();
-        Module::<T>::set_role(Some(&target), role);
+       <Module<T> as RoleManager<T::AccountId, T::Role>>::grant_role(Some(&target), role);
     }: _(RawOrigin::Root, Some(target_lookup), role)
     verify {
         assert_eq!(Module::<T>::has_role(&target, role), false);

--- a/pallets/bylaws/src/lib.rs
+++ b/pallets/bylaws/src/lib.rs
@@ -68,7 +68,7 @@ decl_storage! {
     add_extra_genesis {
         config(roles): Vec<(T::Role, Option<T::AccountId>)>;
         build(|config: &GenesisConfig<T>| {
-            config.roles.iter().for_each(|(role, target)| <Module<T> as RoleManager<T::AccountId, T::Role>>::grant_role(target.as_ref(), *role));
+            config.roles.iter().for_each(|(role, target)| <Module<T> as RoleManager>::grant_role(target.as_ref(), *role));
         })
     }
 }
@@ -98,7 +98,7 @@ decl_module! {
                 None => None,
             };
 
-            <Self as RoleManager<T::AccountId, T::Role>>::grant_role(target.as_ref(), role);
+            <Self as RoleManager>::grant_role(target.as_ref(), role);
             Self::deposit_event(RawEvent::RoleGranted(target, role));
         }
 
@@ -112,22 +112,26 @@ decl_module! {
                 None => None,
             };
 
-            <Self as RoleManager<T::AccountId, T::Role>>::revoke_role(target.as_ref(), role);
+            <Self as RoleManager>::revoke_role(target.as_ref(), role);
             Self::deposit_event(RawEvent::RoleRevoked(target, role));
         }
     }
 }
 
-impl<T: Trait> RoleManager<T::AccountId, T::Role> for Module<T> {
-    fn grant_role(target: Option<&T::AccountId>, role: T::Role) {
+impl<T: Trait> RoleManager for Module<T> {
+    type AccountId = T::AccountId;
+    type Role = T::Role;
+
+    fn grant_role(target: Option<&Self::AccountId>, role: Self::Role) {
         Roles::<T>::mutate(role, target, |d| *d = true)
     }
 
-    fn revoke_role(target: Option<&T::AccountId>, role: T::Role) {
+    fn revoke_role(target: Option<&Self::AccountId>, role: Self::Role) {
         Roles::<T>::remove(role, target)
     }
 
-    fn has_role(target: &T::AccountId, role: T::Role) -> bool {
-        Roles::<T>::get(role, Some(target)) || Roles::<T>::get(role, None as Option<&T::AccountId>)
+    fn has_role(target: &Self::AccountId, role: Self::Role) -> bool {
+        Roles::<T>::get(role, Some(target))
+            || Roles::<T>::get(role, None as Option<&Self::AccountId>)
     }
 }

--- a/pallets/bylaws/src/lib.rs
+++ b/pallets/bylaws/src/lib.rs
@@ -24,7 +24,7 @@
 
 use frame_support::{decl_event, decl_module, decl_storage, traits::Get, weights::Weight};
 use frame_system::ensure_root;
-use governance_os_support::acl::{CallFilter, Role};
+use governance_os_support::acl::{CallFilter, Role, RoleManager};
 use sp_runtime::traits::StaticLookup;
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -68,7 +68,7 @@ decl_storage! {
     add_extra_genesis {
         config(roles): Vec<(T::Role, Option<T::AccountId>)>;
         build(|config: &GenesisConfig<T>| {
-            config.roles.iter().for_each(|(role, target)| Module::<T>::set_role(target.as_ref(), *role));
+            config.roles.iter().for_each(|(role, target)| <Module<T> as RoleManager<T::AccountId, T::Role>>::grant_role(target.as_ref(), *role));
         })
     }
 }
@@ -98,7 +98,7 @@ decl_module! {
                 None => None,
             };
 
-            Self::set_role(target.as_ref(), role);
+            <Self as RoleManager<T::AccountId, T::Role>>::grant_role(target.as_ref(), role);
             Self::deposit_event(RawEvent::RoleGranted(target, role));
         }
 
@@ -112,22 +112,22 @@ decl_module! {
                 None => None,
             };
 
-            Self::unset_role(target.as_ref(), role);
+            <Self as RoleManager<T::AccountId, T::Role>>::revoke_role(target.as_ref(), role);
             Self::deposit_event(RawEvent::RoleRevoked(target, role));
         }
     }
 }
 
-impl<T: Trait> Module<T> {
-    fn set_role(target: Option<&T::AccountId>, role: T::Role) {
+impl<T: Trait> RoleManager<T::AccountId, T::Role> for Module<T> {
+    fn grant_role(target: Option<&T::AccountId>, role: T::Role) {
         Roles::<T>::mutate(role, target, |d| *d = true)
     }
 
-    fn unset_role(target: Option<&T::AccountId>, role: T::Role) {
+    fn revoke_role(target: Option<&T::AccountId>, role: T::Role) {
         Roles::<T>::remove(role, target)
     }
 
-    pub fn has_role(target: &T::AccountId, role: T::Role) -> bool {
+    fn has_role(target: &T::AccountId, role: T::Role) -> bool {
         Roles::<T>::get(role, Some(target)) || Roles::<T>::get(role, None as Option<&T::AccountId>)
     }
 }

--- a/pallets/bylaws/src/lib.rs
+++ b/pallets/bylaws/src/lib.rs
@@ -131,9 +131,9 @@ impl<T: Trait> RoleManager for Module<T> {
     }
 
     fn has_role(target: &Self::AccountId, role: Self::Role) -> bool {
-        Roles::<T>::get(role, Some(target))
-            || Roles::<T>::get(role, None as Option<&Self::AccountId>)
-            || Roles::<T>::get(T::RootRole::get(), Some(target))
-            || Roles::<T>::get(T::RootRole::get(), None as Option<&Self::AccountId>)
+        Roles::<T>::contains_key(role, Some(target))
+            || Roles::<T>::contains_key(role, None as Option<&Self::AccountId>)
+            || Roles::<T>::contains_key(T::RootRole::get(), Some(target))
+            || Roles::<T>::contains_key(T::RootRole::get(), None as Option<&Self::AccountId>)
     }
 }

--- a/pallets/bylaws/src/lib.rs
+++ b/pallets/bylaws/src/lib.rs
@@ -133,5 +133,7 @@ impl<T: Trait> RoleManager for Module<T> {
     fn has_role(target: &Self::AccountId, role: Self::Role) -> bool {
         Roles::<T>::get(role, Some(target))
             || Roles::<T>::get(role, None as Option<&Self::AccountId>)
+            || Roles::<T>::get(T::RootRole::get(), Some(target))
+            || Roles::<T>::get(T::RootRole::get(), None as Option<&Self::AccountId>)
     }
 }

--- a/pallets/bylaws/src/signed_extra.rs
+++ b/pallets/bylaws/src/signed_extra.rs
@@ -20,7 +20,7 @@ use frame_support::{
     traits::{Get, GetCallMetadata},
     weights::DispatchInfo,
 };
-use governance_os_support::acl::CallFilter;
+use governance_os_support::acl::{CallFilter, RoleManager};
 use sp_runtime::{
     traits::{DispatchInfoOf, Dispatchable, SignedExtension},
     transaction_validity::{

--- a/pallets/bylaws/src/signed_extra.rs
+++ b/pallets/bylaws/src/signed_extra.rs
@@ -16,10 +16,7 @@
 
 use crate::{Module, Trait};
 use codec::{Decode, Encode};
-use frame_support::{
-    traits::{Get, GetCallMetadata},
-    weights::DispatchInfo,
-};
+use frame_support::{traits::GetCallMetadata, weights::DispatchInfo};
 use governance_os_support::acl::{CallFilter, RoleManager};
 use sp_runtime::{
     traits::{DispatchInfoOf, Dispatchable, SignedExtension},
@@ -63,7 +60,6 @@ where
         let roles = T::CallFilter::roles_for(who, call, info, len);
         // Either `who` is root either it has one of the roles needed.
         if roles.is_empty()
-            || Module::<T>::has_role(who, T::RootRole::get())
             || roles
                 .iter()
                 .cloned()

--- a/pallets/bylaws/src/tests/dispatchable.rs
+++ b/pallets/bylaws/src/tests/dispatchable.rs
@@ -17,7 +17,7 @@
 use super::mock::*;
 use frame_support::assert_ok;
 use frame_system::RawOrigin;
-use governance_os_support::testing::ALICE;
+use governance_os_support::{acl::RoleManager, testing::ALICE};
 
 #[test]
 fn grant_role() {

--- a/pallets/bylaws/src/tests/genesis.rs
+++ b/pallets/bylaws/src/tests/genesis.rs
@@ -17,7 +17,10 @@
 use super::mock::*;
 use crate::Roles;
 use frame_support::storage::StorageDoubleMap;
-use governance_os_support::testing::{primitives::AccountId, ALICE, BOB};
+use governance_os_support::{
+    acl::RoleManager,
+    testing::{primitives::AccountId, ALICE, BOB},
+};
 
 #[test]
 fn register_role() {

--- a/pallets/bylaws/src/tests/mock.rs
+++ b/pallets/bylaws/src/tests/mock.rs
@@ -14,15 +14,20 @@
  * limitations under the License.
  */
 
-use crate::{CheckRole, GenesisConfig, Module, Trait};
+use crate::{
+    self as governance_os_pallet_bylaws, // compat with `mock_runtime`
+    CheckRole,
+    GenesisConfig,
+    Trait,
+};
 use codec::{Decode, Encode};
 use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types};
 use governance_os_support::{
     acl::{CallFilter, Role},
-    impl_enum_default,
+    impl_enum_default, mock_runtime,
     testing::{
-        primitives::AccountId, AvailableBlockRatio, BlockHashCount, MaximumBlockLength,
-        MaximumBlockWeight, ALICE,
+        primitives::{AccountId, CurrencyId},
+        AvailableBlockRatio, BlockHashCount, MaximumBlockLength, MaximumBlockWeight, ALICE,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -32,87 +37,10 @@ use sp_runtime::{
     traits::{BlakeTwo256, DispatchInfoOf, IdentityLookup},
     RuntimeDebug,
 };
-use sp_std::{fmt::Debug, marker};
+use sp_std::marker;
 
-impl_outer_origin! {
-    pub enum Origin for Test {}
-}
+mock_runtime!(Test, ());
 
-impl_outer_dispatch! {
-    pub enum Call for Test where origin: Origin {
-        frame_system::System,
-    }
-}
-
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub struct Test;
-
-impl frame_system::Trait for Test {
-    type BaseCallFilter = ();
-    type Origin = Origin;
-    type Call = Call;
-    type Index = u64;
-    type BlockNumber = u64;
-    type Hash = H256;
-    type Hashing = BlakeTwo256;
-    type AccountId = AccountId;
-    type Lookup = IdentityLookup<Self::AccountId>;
-    type Header = Header;
-    type Event = ();
-    type BlockHashCount = BlockHashCount;
-    type MaximumBlockWeight = MaximumBlockWeight;
-    type DbWeight = ();
-    type BlockExecutionWeight = ();
-    type ExtrinsicBaseWeight = ();
-    type MaximumExtrinsicWeight = MaximumBlockWeight;
-    type MaximumBlockLength = MaximumBlockLength;
-    type AvailableBlockRatio = AvailableBlockRatio;
-    type Version = ();
-    type PalletInfo = ();
-    type AccountData = ();
-    type OnNewAccount = ();
-    type OnKilledAccount = ();
-    type SystemWeightInfo = ();
-}
-
-#[derive(Eq, PartialEq, RuntimeDebug, Encode, Decode, Copy, Clone, Serialize, Deserialize)]
-pub enum MockRoles {
-    Root,
-    RemarkOnly,
-}
-impl Role for MockRoles {}
-impl_enum_default!(MockRoles, RemarkOnly);
-
-pub struct MockCallFilter<T>(marker::PhantomData<T>);
-impl<T: Trait> CallFilter<AccountId, Call, MockRoles> for MockCallFilter<T> {
-    fn roles_for(
-        _who: &AccountId,
-        call: &Call,
-        _info: &DispatchInfoOf<Call>,
-        _len: usize,
-    ) -> Vec<MockRoles> {
-        match call {
-            Call::System(frame_system::Call::remark(..)) => vec![MockRoles::RemarkOnly],
-            Call::System(frame_system::Call::suicide()) => vec![], // Everybody can call it
-            _ => vec![MockRoles::Root],
-        }
-    }
-}
-
-parameter_types! {
-    pub const RootRole: MockRoles = MockRoles::Root;
-}
-
-impl Trait for Test {
-    type Event = ();
-    type Role = MockRoles;
-    type RootRole = RootRole;
-    type CallFilter = MockCallFilter<Test>;
-    type WeightInfo = ();
-}
-
-pub type System = frame_system::Module<Test>;
-pub type Bylaws = Module<Test>;
 pub type MockCheckRole = CheckRole<Test>;
 
 pub struct ExtBuilder {

--- a/pallets/bylaws/src/tests/mock.rs
+++ b/pallets/bylaws/src/tests/mock.rs
@@ -39,7 +39,7 @@ use sp_runtime::{
 };
 use sp_std::marker;
 
-mock_runtime!(Test, ());
+mock_runtime!(Test);
 
 pub type MockCheckRole = CheckRole<Test>;
 

--- a/pallets/bylaws/src/tests/role_manager.rs
+++ b/pallets/bylaws/src/tests/role_manager.rs
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::mock::*;
+use governance_os_support::{acl::RoleManager, testing::ALICE};
+
+#[test]
+fn root_has_all_roles() {
+    ExtBuilder::default()
+        .alice_as_root()
+        .build()
+        .execute_with(|| assert_eq!(Bylaws::has_role(&ALICE, MockRoles::RemarkOnly), true))
+}

--- a/pallets/tokens/Cargo.toml
+++ b/pallets/tokens/Cargo.toml
@@ -24,6 +24,7 @@ sp-runtime = { default-features = false, version = '2.0.0' }
 sp-std = { default-features = false, version = "2.0.0" }
 
 [dev-dependencies]
+governance-os-pallet-bylaws = { path = '../bylaws' }
 sp-core = '2.0.0'
 sp-io = '2.0.0'
 

--- a/pallets/tokens/src/currencies.rs
+++ b/pallets/tokens/src/currencies.rs
@@ -85,6 +85,12 @@ impl<T: Trait> Currencies<T::AccountId> for Module<T> {
         who: &T::AccountId,
         amount: Self::Balance,
     ) -> DispatchResult {
+        // First verify permissions
+        if !RoleManagerOf::<T>::has_role(who, RoleBuilderOf::<T>::transfer_currency(currency_id)) {
+            return Err(Error::<T>::UnTransferableCurrency.into());
+        }
+
+        // Then balances
         let _new_balance = Self::free_balance(currency_id, who)
             .checked_sub(&amount)
             .ok_or(Error::<T>::BalanceTooLow)?;

--- a/pallets/tokens/src/default_weights.rs
+++ b/pallets/tokens/src/default_weights.rs
@@ -20,28 +20,28 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 impl crate::WeightInfo for () {
     fn create() -> Weight {
-        (60_000_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
+        (74_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(7 as Weight))
+            .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     fn mint() -> Weight {
-        (108_000_000 as Weight)
-            .saturating_add(DbWeight::get().reads(7 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
-    }
-    fn burn() -> Weight {
         (112_000_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
+    fn burn() -> Weight {
+        (113_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(7 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
+    }
     fn update_details() -> Weight {
-        (60_000_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
+        (90_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(7 as Weight))
+            .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     fn transfer() -> Weight {
-        (133_000_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
+        (160_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
 }

--- a/pallets/tokens/src/details.rs
+++ b/pallets/tokens/src/details.rs
@@ -28,4 +28,8 @@ pub struct CurrencyDetails<AccountId> {
     /// The owner of the currency, typically it can mint or burn units of this
     /// currency.
     pub owner: AccountId,
+
+    /// Wether the currency is transferrable. If set to false no account will be
+    /// able to transfer the tokens to each other.
+    pub transferable: bool,
 }

--- a/pallets/tokens/src/tests/currencies.rs
+++ b/pallets/tokens/src/tests/currencies.rs
@@ -293,3 +293,14 @@ fn repatriate_reserved_reserved_balance() {
             assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &BOB), 50);
         })
 }
+
+#[test]
+fn ensure_can_withdraw_refuse_if_non_transferable_currency() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_ok!(Tokens::create(Origin::signed(TEST_TOKEN_OWNER), 42, false));
+        assert_noop!(
+            <Tokens as Currencies<AccountId>>::transfer(42, &ALICE, &BOB, 50),
+            Error::<Test>::UnTransferableCurrency
+        );
+    })
+}

--- a/pallets/tokens/src/tests/genesis.rs
+++ b/pallets/tokens/src/tests/genesis.rs
@@ -15,6 +15,8 @@
  */
 
 use super::mock::*;
+use crate::RoleBuilder;
+use governance_os_support::acl::RoleManager;
 
 #[test]
 fn set_storage_correctly() {
@@ -38,8 +40,15 @@ fn does_not_set_balances_by_default() {
 }
 
 #[test]
-fn set_test_token_details_approprietaly() {
-    ExtBuilder::default()
-        .build()
-        .execute_with(|| assert_eq!(Tokens::details(TEST_TOKEN_ID).owner, TEST_TOKEN_OWNER))
+fn set_test_token_roles_approprietaly() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_eq!(
+            Bylaws::has_role(&TEST_TOKEN_OWNER, MockRoles::manage_currency(TEST_TOKEN_ID)),
+            true
+        );
+        assert_eq!(
+            Bylaws::has_role(&ALICE, MockRoles::transfer_currency(TEST_TOKEN_ID)),
+            true
+        );
+    })
 }

--- a/pallets/tokens/src/tests/mock.rs
+++ b/pallets/tokens/src/tests/mock.rs
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-use crate::{CurrencyDetails, GenesisConfig, Module, NativeCurrencyAdapter, Trait};
-use frame_support::{impl_outer_origin, parameter_types};
+use crate::{CurrencyDetails, GenesisConfig, Module, NativeCurrencyAdapter, RoleBuilder, Trait};
+use codec::{Decode, Encode};
+use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types};
 pub use governance_os_support::{
+    acl::{CallFilter, Role},
+    impl_enum_default,
     testing::{
         primitives::{AccountId, Balance, CurrencyId},
         AvailableBlockRatio, BlockHashCount, MaximumBlockLength, MaximumBlockWeight, ALICE, BOB,
@@ -24,11 +27,14 @@ pub use governance_os_support::{
     },
     Currencies, ReservableCurrencies,
 };
+use serde::{Deserialize, Serialize};
 use sp_core::H256;
 use sp_runtime::{
     testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
+    traits::{BlakeTwo256, DispatchInfoOf, IdentityLookup},
+    RuntimeDebug,
 };
+use sp_std::marker;
 
 impl_outer_origin! {
     pub enum Origin for Test {}
@@ -37,10 +43,16 @@ impl_outer_origin! {
 #[derive(Clone, Eq, PartialEq)]
 pub struct Test;
 
+impl_outer_dispatch! {
+    pub enum Call for Test where origin: Origin {
+        frame_system::System,
+    }
+}
+
 impl frame_system::Trait for Test {
     type BaseCallFilter = ();
     type Origin = Origin;
-    type Call = ();
+    type Call = Call;
     type Index = u64;
     type BlockNumber = u64;
     type Hash = H256;
@@ -65,18 +77,71 @@ impl frame_system::Trait for Test {
     type SystemWeightInfo = ();
 }
 
+#[derive(Eq, PartialEq, RuntimeDebug, Encode, Decode, Copy, Clone, Serialize, Deserialize)]
+pub enum MockRoles {
+    Root,
+    RemarkOnly,
+    TransferCurrency(CurrencyId),
+    ManageCurrency(CurrencyId),
+}
+impl Role for MockRoles {}
+impl_enum_default!(MockRoles, RemarkOnly);
+impl RoleBuilder for MockRoles {
+    type CurrencyId = CurrencyId;
+    type Role = Self;
+
+    fn transfer_currency(id: CurrencyId) -> Self {
+        Self::TransferCurrency(id)
+    }
+
+    fn manage_currency(id: CurrencyId) -> Self {
+        Self::ManageCurrency(id)
+    }
+}
+
+pub struct MockCallFilter<T>(marker::PhantomData<T>);
+impl<T: Trait> CallFilter<AccountId, Call, MockRoles> for MockCallFilter<T> {
+    fn roles_for(
+        _who: &AccountId,
+        call: &Call,
+        _info: &DispatchInfoOf<Call>,
+        _len: usize,
+    ) -> Vec<MockRoles> {
+        match call {
+            Call::System(frame_system::Call::remark(..)) => vec![MockRoles::RemarkOnly],
+            Call::System(frame_system::Call::suicide()) => vec![], // Everybody can call it
+            _ => vec![MockRoles::Root],
+        }
+    }
+}
+
+parameter_types! {
+    pub const RootRole: MockRoles = MockRoles::Root;
+}
+
+impl governance_os_pallet_bylaws::Trait for Test {
+    type Event = ();
+    type Role = MockRoles;
+    type RootRole = RootRole;
+    type CallFilter = MockCallFilter<Test>;
+    type WeightInfo = ();
+}
+
 impl Trait for Test {
     type Event = ();
     type CurrencyId = CurrencyId;
     type Balance = Balance;
     type WeightInfo = ();
     type AccountStore = System;
+    type RoleManager = Bylaws;
+    type RoleBuilder = MockRoles;
 }
 
 parameter_types! {
     pub const GetTestTokenId: CurrencyId = TEST_TOKEN_ID;
 }
 
+pub type Bylaws = governance_os_pallet_bylaws::Module<Test>;
 pub type System = frame_system::Module<Test>;
 pub type Tokens = Module<Test>;
 pub type TokensCurrencyAdapter = NativeCurrencyAdapter<Test, GetTestTokenId>;
@@ -92,6 +157,7 @@ impl Default for ExtBuilder {
             endowed_accounts: vec![],
             test_token_details: CurrencyDetails {
                 owner: TEST_TOKEN_OWNER,
+                transferable: true,
             },
         }
     }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -16,6 +16,7 @@ version = '1.3.4'
 
 [dependencies]
 frame-system = { version = '2.0.0', default-features = false }
+governance-os-pallet-tokens = { path = '../pallets/tokens', default-features = false }
 governance-os-support = { path = '../support', default-features = false }
 serde = { version = '1.0.116', optional = true }
 sp-application-crypto = { version = '2.0.0', default-features = false }
@@ -28,6 +29,7 @@ default = ['std']
 std = [
 	'codec/std',
 	'frame-system/std',
+	'governance-os-pallet-tokens/std',
 	'governance-os-support/std',
 	'serde',
 	'sp-application-crypto/std',

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -73,7 +73,21 @@ pub type Block = generic::Block<Header, OpaqueExtrinsic>;
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum Role {
     CreateCurrencies,
+    ManageCurrency(CurrencyId),
     Root,
+    TransferCurrency(CurrencyId),
 }
 impl governance_os_support::acl::Role for Role {}
 impl_enum_default!(Role, Root);
+impl governance_os_pallet_tokens::RoleBuilder for Role {
+    type CurrencyId = CurrencyId;
+    type Role = Role;
+
+    fn transfer_currency(id: CurrencyId) -> Role {
+        Role::TransferCurrency(id)
+    }
+
+    fn manage_currency(id: CurrencyId) -> Role {
+        Role::ManageCurrency(id)
+    }
+}

--- a/runtime/src/pallets_economics.rs
+++ b/runtime/src/pallets_economics.rs
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-use crate::{Event, Runtime, System};
+use crate::{Bylaws, Event, Runtime, System};
 use frame_support::{parameter_types, weights::IdentityFee};
 use governance_os_pallet_tokens::NativeCurrencyAdapter;
-use governance_os_primitives::{Balance, CurrencyId};
+use governance_os_primitives::{Balance, CurrencyId, Role};
 
 impl governance_os_pallet_tokens::Trait for Runtime {
     type Event = Event;
@@ -25,6 +25,8 @@ impl governance_os_pallet_tokens::Trait for Runtime {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type AccountStore = System;
+    type RoleBuilder = Role;
+    type RoleManager = Bylaws;
 }
 
 parameter_types! {

--- a/support/Cargo.toml
+++ b/support/Cargo.toml
@@ -17,6 +17,7 @@ version = '1.3.4'
 
 [dependencies]
 frame-support = { version = '2.0.0', default-features = false }
+frame-system = { version = '2.0.0', default-features = false }
 sp-runtime = { version = '2.0.0', default-features = false }
 sp-std = { version = '2.0.0', default-features = false }
 
@@ -25,6 +26,7 @@ default = ['std']
 std = [
 	'codec/std',
 	'frame-support/std',
+	'frame-system/std',
     'sp-runtime/std',
 	'sp-std/std',
 ]

--- a/support/src/acl.rs
+++ b/support/src/acl.rs
@@ -45,3 +45,19 @@ where
         len: usize,
     ) -> Vec<Role>;
 }
+
+/// This trait can be implemented by a pallet to expose an interface for other pallets to
+/// manage their own role based access control features.
+pub trait RoleManager<AccountId, Role> {
+    /// Should return `true` if `traget` has the role `role`. This can be the case
+    /// if the role was granted directly to the target or if it was granted to all accounts.
+    fn has_role(target: &AccountId, role: Role) -> bool;
+
+    /// Grants `target` the role `role`. If target is `None` then it should give the role to
+    /// every account that exists or may exists on the chain.
+    fn grant_role(target: Option<&AccountId>, role: Role);
+
+    /// Should revoke the role `role` for `target`. If the role wasn't granted to `target` this
+    /// should be a no op.
+    fn revoke_role(target: Option<&AccountId>, role: Role);
+}

--- a/support/src/acl.rs
+++ b/support/src/acl.rs
@@ -18,8 +18,26 @@
 //! runtime users.
 
 use frame_support::Parameter;
-use sp_runtime::traits::{DispatchInfoOf, Dispatchable, MaybeSerializeDeserialize, Member};
-use sp_std::prelude::Vec;
+use frame_system::{ensure_signed, RawOrigin};
+use sp_runtime::{
+    traits::{DispatchInfoOf, Dispatchable, MaybeSerializeDeserialize, Member},
+    DispatchError,
+};
+use sp_std::{convert::Into, prelude::Vec};
+
+pub enum AclError {
+    MissingRole,
+}
+
+impl Into<DispatchError> for AclError {
+    fn into(self) -> DispatchError {
+        match self {
+            AclError::MissingRole => {
+                DispatchError::Other("account doesn't have the required role(s)")
+            }
+        }
+    }
+}
 
 /// This defines a role. Roles can be granted to any number of addresses, frozen
 /// (denied for anybody) and granted to everybody at once.
@@ -48,16 +66,35 @@ where
 
 /// This trait can be implemented by a pallet to expose an interface for other pallets to
 /// manage their own role based access control features.
-pub trait RoleManager<AccountId, Role> {
+pub trait RoleManager {
+    type AccountId;
+    type Role;
+
     /// Should return `true` if `traget` has the role `role`. This can be the case
     /// if the role was granted directly to the target or if it was granted to all accounts.
-    fn has_role(target: &AccountId, role: Role) -> bool;
+    fn has_role(target: &Self::AccountId, role: Self::Role) -> bool;
 
     /// Grants `target` the role `role`. If target is `None` then it should give the role to
     /// every account that exists or may exists on the chain.
-    fn grant_role(target: Option<&AccountId>, role: Role);
+    fn grant_role(target: Option<&Self::AccountId>, role: Self::Role);
 
     /// Should revoke the role `role` for `target`. If the role wasn't granted to `target` this
     /// should be a no op.
-    fn revoke_role(target: Option<&AccountId>, role: Role);
+    fn revoke_role(target: Option<&Self::AccountId>, role: Self::Role);
+
+    /// A helper function that will require the origin to have the `role` granted. We provide a
+    /// default implementation for it.
+    fn ensure_has_role<OuterOrigin>(
+        origin: OuterOrigin,
+        role: Self::Role,
+    ) -> Result<Self::AccountId, DispatchError>
+    where
+        OuterOrigin: Into<Result<RawOrigin<Self::AccountId>, OuterOrigin>>,
+    {
+        let who = ensure_signed(origin)?;
+        match Self::has_role(&who, role) {
+            true => Ok(who),
+            false => Err(AclError::MissingRole.into()),
+        }
+    }
 }

--- a/support/src/testing.rs
+++ b/support/src/testing.rs
@@ -45,6 +45,10 @@ pub mod primitives {
 /// other pallets of the Governance OS project are supposed to depend on those; so
 /// better not write the same code twice.
 macro_rules! mock_runtime {
+    ($runtime:tt) => {
+        mock_runtime!($runtime, ());
+    };
+
     ($runtime:tt, $account_data:ty) => {
         #[derive(Clone, Eq, PartialEq, RuntimeDebug)]
         pub struct $runtime;


### PR DESCRIPTION
This PR introduces a new feature relying on the `RoleManager` trait in order to let pallets set their own bylaws and use those to handle delegate to the `bylaws` pallet the management of their own access control checks.
It also features a few code and storage optimizations along other housekeeping tasks.
