### PR TITLE
sudo compat module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,6 +1974,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "governance-os-pallet-compat"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "governance-os-pallet-bylaws",
+ "governance-os-support",
+ "parity-scale-codec",
+ "sp-runtime",
+]
+
+[[package]]
 name = "governance-os-pallet-tokens"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1982,6 +1982,9 @@ dependencies = [
  "governance-os-pallet-bylaws",
  "governance-os-support",
  "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
  "sp-runtime",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,6 +1986,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -2032,6 +2033,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "governance-os-pallet-bylaws",
+ "governance-os-pallet-compat",
  "governance-os-pallet-tokens",
  "governance-os-primitives",
  "governance-os-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,9 @@ panic = 'unwind'
 members = [
     'node',
     'pallets/bylaws',
+    'pallets/compat',
     'pallets/tokens',
     'primitives',
     'runtime',
     'support',
-] 
+]

--- a/pallets/compat/Cargo.toml
+++ b/pallets/compat/Cargo.toml
@@ -20,6 +20,7 @@ frame-system = { default-features = false, version = '2.0.0' }
 governance-os-pallet-bylaws = { default-features = false, path = '../bylaws' }
 governance-os-support = { default-features = false, path = '../../support' }
 sp-runtime = { default-features = false, version = '2.0.0' }
+sp-std = { default-features = false, version = "2.0.0" }
 
 [dev-dependencies]
 serde = '1.0.116'
@@ -35,4 +36,5 @@ std = [
     'governance-os-pallet-bylaws/std',
     'governance-os-support/std',
     'sp-runtime/std',
+    'sp-std/std',
 ]

--- a/pallets/compat/Cargo.toml
+++ b/pallets/compat/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+edition = '2018'
+license = 'Apache 2.0'
+name = 'governance-os-pallet-compat'
+version = '0.1.0'
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+# alias "parity-scale-code" to "codec"
+[dependencies.codec]
+default-features = false
+features = ['derive']
+package = 'parity-scale-codec'
+version = '1.3.4'
+
+[dependencies]
+frame-support = { default-features = false, version = '2.0.0' }
+frame-system = { default-features = false, version = '2.0.0' }
+governance-os-pallet-bylaws = { default-features = false, path = '../bylaws' }
+governance-os-support = { default-features = false, path = '../../support' }
+sp-runtime = { default-features = false, version = '2.0.0' }
+
+[features]
+default = ['std']
+std = [
+    'codec/std',
+    'frame-support/std',
+    'frame-system/std',
+    'governance-os-pallet-bylaws/std',
+    'governance-os-support/std',
+    'sp-runtime/std',
+]

--- a/pallets/compat/Cargo.toml
+++ b/pallets/compat/Cargo.toml
@@ -7,7 +7,7 @@ version = '0.1.0'
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
 
-# alias "parity-scale-code" to "codec"
+# alias 'parity-scale-code' to 'codec'
 [dependencies.codec]
 default-features = false
 features = ['derive']
@@ -20,6 +20,11 @@ frame-system = { default-features = false, version = '2.0.0' }
 governance-os-pallet-bylaws = { default-features = false, path = '../bylaws' }
 governance-os-support = { default-features = false, path = '../../support' }
 sp-runtime = { default-features = false, version = '2.0.0' }
+
+[dev-dependencies]
+serde = '1.0.116'
+sp-core = '2.0.0'
+sp-io = '2.0.0'
 
 [features]
 default = ['std']

--- a/pallets/compat/src/lib.rs
+++ b/pallets/compat/src/lib.rs
@@ -26,7 +26,7 @@ use frame_support::{
     decl_event, decl_module, decl_storage,
     dispatch::DispatchResultWithPostInfo,
     traits::{Get, UnfilteredDispatchable},
-    weights::{GetDispatchInfo, Pays},
+    weights::{GetDispatchInfo, Pays, Weight},
     Parameter,
 };
 use governance_os_pallet_bylaws::RoleBuilder;
@@ -81,6 +81,14 @@ decl_module! {
 
             // Caller won't pay a fee.
             Ok(Pays::No.into())
+        }
+
+        /// A variant of the `sudo` dispatchable that will let caller specify its weight. This could be
+        /// useful when trying to push a runtime upgrade but should be used with parcimony.
+        #[weight = (*_weight, call.get_dispatch_info().class)]
+        fn sudo_custom_weight(origin, call: Box<<T as Trait>::Call>, _weight: Weight) -> DispatchResultWithPostInfo {
+            // Just proxy back to the `sudo` call
+            Self::sudo(origin, call)
         }
 
         // Dispatches the call with the origin set to `who`.

--- a/pallets/compat/src/lib.rs
+++ b/pallets/compat/src/lib.rs
@@ -32,6 +32,7 @@ use frame_support::{
 use governance_os_pallet_bylaws::RoleBuilder;
 use governance_os_support::acl::RoleManager;
 use sp_runtime::{traits::StaticLookup, DispatchResult};
+use sp_std::boxed::Box;
 
 #[cfg(test)]
 mod tests;

--- a/pallets/compat/src/lib.rs
+++ b/pallets/compat/src/lib.rs
@@ -33,6 +33,9 @@ use governance_os_pallet_bylaws::RoleBuilder;
 use governance_os_support::acl::RoleManager;
 use sp_runtime::{traits::StaticLookup, DispatchResult};
 
+#[cfg(test)]
+mod tests;
+
 pub trait Trait: frame_system::Trait {
     /// Because this pallet emits events, it depends on the runtime's definition of an event.
     type Event: From<Event> + Into<<Self as frame_system::Trait>::Event>;

--- a/pallets/compat/src/lib.rs
+++ b/pallets/compat/src/lib.rs
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! This pallet handles compatibility between the "legacy" substrate ACL system
+//! which distinguishes between account origins and a root origin. It lets users
+//! with a `Root` role trigger calls dispatched with the substrate root origin,
+//! typically this gives the possibility to trigger upgrade to the chains and
+//! interact with modules that do not support our bylaws system.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::{
+    decl_event, decl_module, decl_storage,
+    dispatch::DispatchResultWithPostInfo,
+    traits::{Get, UnfilteredDispatchable},
+    weights::{GetDispatchInfo, Pays},
+    Parameter,
+};
+use governance_os_pallet_bylaws::RoleBuilder;
+use governance_os_support::acl::RoleManager;
+use sp_runtime::{traits::StaticLookup, DispatchResult};
+
+pub trait Trait: frame_system::Trait {
+    /// Because this pallet emits events, it depends on the runtime's definition of an event.
+    type Event: From<Event> + Into<<Self as frame_system::Trait>::Event>;
+
+    /// A sudo-able call.
+    type Call: Parameter + UnfilteredDispatchable<Origin = Self::Origin> + GetDispatchInfo;
+
+    /// The role builder used by the `bylaws` pallet
+    type RoleBuilder: RoleBuilder<Role = <RoleManagerOf<Self> as RoleManager>::Role>;
+
+    /// Pallet used to manage and check for roles.
+    type RoleManager: RoleManager<AccountId = Self::AccountId>;
+}
+
+type RoleBuilderOf<T> = <T as Trait>::RoleBuilder;
+type RoleManagerOf<T> = <T as Trait>::RoleManager;
+
+decl_storage! {
+    trait Store for Module<T: Trait> as Compat {}
+}
+
+decl_event!(
+    pub enum Event {
+        /// A sudo just took place. [result]
+        CompatSudid(DispatchResult),
+        /// A root user just performed a call as someone else. [result]
+        CompatDidAs(DispatchResult),
+    }
+);
+
+decl_module! {
+    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        fn deposit_event() = default;
+
+        /// Dispatches the given call with a `Root` origin.
+        #[weight = (call.get_dispatch_info().weight + 10_000, call.get_dispatch_info().class)]
+        fn sudo(origin, call: Box<<T as Trait>::Call>) -> DispatchResultWithPostInfo {
+            RoleManagerOf::<T>::ensure_has_role(origin, RoleBuilderOf::<T>::root())?;
+
+            let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Root.into());
+            Self::deposit_event(Event::CompatSudid(res.map(|_| ()).map_err(|e| e.error)));
+
+            // Caller won't pay a fee.
+            Ok(Pays::No.into())
+        }
+
+        // Dispatches the call with the origin set to `who`.
+        #[weight = (
+            call.get_dispatch_info().weight
+                .saturating_add(10_000)
+                 // AccountData for inner call origin accountdata.
+                .saturating_add(T::DbWeight::get().reads_writes(1, 1))
+                // Two read performed by ensure_has_role
+                .saturating_add(T::DbWeight::get().reads(2)),
+            call.get_dispatch_info().class
+        )]
+        fn doas(origin,
+            who: <T::Lookup as StaticLookup>::Source,
+            call: Box<<T as Trait>::Call>
+        ) -> DispatchResultWithPostInfo {
+            RoleManagerOf::<T>::ensure_has_role(origin, RoleBuilderOf::<T>::root())?;
+
+            let who = T::Lookup::lookup(who)?;
+
+            let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Signed(who).into());
+            Self::deposit_event(Event::CompatDidAs(res.map(|_| ()).map_err(|e| e.error)));
+
+            // Sudo user does not pay a fee.
+            Ok(Pays::No.into())
+        }
+    }
+}

--- a/pallets/compat/src/tests/dispatchable.rs
+++ b/pallets/compat/src/tests/dispatchable.rs
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::mock::*;
+use frame_support::{assert_noop, assert_ok};
+use governance_os_support::{
+    acl::AclError,
+    testing::{ALICE, BOB},
+};
+
+fn mock_call() -> Box<Call> {
+    Box::new(Call::System(frame_system::Call::remark(vec![])))
+}
+
+#[test]
+fn test_sudo_root() {
+    ExtBuilder::default()
+        .with_root(ALICE)
+        .build()
+        .execute_with(|| {
+            assert_ok!(Compat::sudo(Origin::signed(ALICE), mock_call()));
+        })
+}
+
+#[test]
+fn test_sudo_not_root() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            Compat::sudo(Origin::signed(ALICE), mock_call()),
+            AclError::MissingRole
+        );
+    })
+}
+
+#[test]
+fn test_doas_root() {
+    ExtBuilder::default()
+        .with_root(ALICE)
+        .build()
+        .execute_with(|| {
+            assert_ok!(Compat::doas(Origin::signed(ALICE), BOB, mock_call()));
+        })
+}
+
+#[test]
+fn test_doas_not_root() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            Compat::doas(Origin::signed(ALICE), BOB, mock_call()),
+            AclError::MissingRole
+        );
+    })
+}

--- a/pallets/compat/src/tests/mock.rs
+++ b/pallets/compat/src/tests/mock.rs
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::{Module, Trait};
+use codec::{Decode, Encode};
+use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types};
+pub use governance_os_support::{
+    acl::Role,
+    impl_enum_default, mock_runtime,
+    testing::{
+        primitives::{AccountId, Balance, CurrencyId},
+        AvailableBlockRatio, BlockHashCount, MaximumBlockLength, MaximumBlockWeight, ALICE, BOB,
+        TEST_TOKEN_ID, TEST_TOKEN_OWNER,
+    },
+    Currencies, ReservableCurrencies,
+};
+use serde::{Deserialize, Serialize};
+use sp_core::H256;
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    RuntimeDebug,
+};
+
+mock_runtime!(Test);
+
+impl Trait for Test {
+    type Event = ();
+    type Call = Call;
+    type RoleManager = Bylaws;
+    type RoleBuilder = MockRoles;
+}
+
+pub type Compat = Module<Test>;
+
+pub struct ExtBuilder {
+    root: Option<AccountId>,
+}
+
+impl Default for ExtBuilder {
+    fn default() -> Self {
+        Self { root: None }
+    }
+}
+
+impl ExtBuilder {
+    pub fn with_root(mut self, root: AccountId) -> Self {
+        self.root = Some(root);
+        self
+    }
+
+    pub fn build(self) -> sp_io::TestExternalities {
+        let mut t = frame_system::GenesisConfig::default()
+            .build_storage::<Test>()
+            .unwrap();
+
+        // We do not want to make everybody root for the tests
+        if self.root.is_some() {
+            governance_os_pallet_bylaws::GenesisConfig::<Test> {
+                roles: vec![(MockRoles::Root, self.root)],
+            }
+            .assimilate_storage(&mut t)
+            .unwrap();
+        }
+
+        let mut ext = sp_io::TestExternalities::new(t);
+        ext.execute_with(|| System::set_block_number(1));
+        ext
+    }
+}

--- a/pallets/compat/src/tests/mod.rs
+++ b/pallets/compat/src/tests/mod.rs
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod dispatchable;
+pub mod mock;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -25,6 +25,7 @@ frame-system = { version = '2.0.0', default-features = false }
 frame-system-benchmarking = { default-features = false, version = '2.0.0', optional = true }
 frame-system-rpc-runtime-api = { version = '2.0.0', default-features = false }
 governance-os-pallet-bylaws = { default-features = false, path = '../pallets/bylaws' }
+governance-os-pallet-compat = { default-features = false, path = '../pallets/compat' }
 governance-os-pallet-tokens = { default-features = false, path = '../pallets/tokens' }
 governance-os-primitives = { default-features = false, path = '../primitives' }
 governance-os-support = { default-features = false, path = '../support' }
@@ -57,6 +58,7 @@ std = [
     'frame-system/std',
     'frame-system-rpc-runtime-api/std',
     'governance-os-pallet-bylaws/std',
+    'governance-os-pallet-compat/std',
     'governance-os-pallet-tokens/std',
     'governance-os-primitives/std',
     'governance-os-support/std',

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -66,6 +66,7 @@ construct_runtime!(
         // Core
         System: frame_system::{Module, Call, Config, Storage, Event<T>},
         RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
+        Compat: governance_os_pallet_compat::{Module, Call, Event},
 
         // Consensus
         Aura: pallet_aura::{Module, Config<T>, Inherent},

--- a/runtime/src/pallets_core.rs
+++ b/runtime/src/pallets_core.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::{weights, Call, Event, Origin, PalletInfo, Runtime, VERSION};
+use crate::{weights, Bylaws, Call, Event, Origin, PalletInfo, Runtime, VERSION};
 use frame_support::{
     parameter_types,
     weights::{
@@ -22,7 +22,7 @@ use frame_support::{
         Weight,
     },
 };
-use governance_os_primitives::{AccountId, Balance, BlockNumber, CurrencyId, Hash, Index};
+use governance_os_primitives::{AccountId, Balance, BlockNumber, CurrencyId, Hash, Index, Role};
 use sp_runtime::{
     generic,
     traits::{BlakeTwo256, IdentityLookup, Saturating},
@@ -74,4 +74,11 @@ impl frame_system::Trait for Runtime {
     type OnNewAccount = ();
     type OnKilledAccount = ();
     type SystemWeightInfo = weights::frame_system::WeightInfo;
+}
+
+impl governance_os_pallet_compat::Trait for Runtime {
+    type Event = Event;
+    type Call = Call;
+    type RoleBuilder = Role;
+    type RoleManager = Bylaws;
 }


### PR DESCRIPTION
This add a pallet to ensure compatibility between the substrate permissioning system used by other pallets from the ecosystem and ours. Basically `compat` is reimplementation of `sudo` supporting our bylaws system.
