### PR TITLE
organizations pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "governance-os-pallet-bylaws",
- "governance-os-pallet-tokens",
  "governance-os-support",
  "parity-scale-codec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,6 +1999,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,9 +1995,13 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
+ "governance-os-pallet-bylaws",
+ "governance-os-pallet-tokens",
  "governance-os-support",
  "parity-scale-codec",
  "serde",
+ "sp-core",
+ "sp-io",
  "sp-runtime",
  "sp-std",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,6 +2028,7 @@ version = "0.1.0"
 dependencies = [
  "frame-system",
  "governance-os-pallet-bylaws",
+ "governance-os-pallet-organizations",
  "governance-os-pallet-tokens",
  "governance-os-support",
  "parity-scale-codec",
@@ -2050,6 +2051,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "governance-os-pallet-bylaws",
  "governance-os-pallet-compat",
+ "governance-os-pallet-organizations",
  "governance-os-pallet-tokens",
  "governance-os-primitives",
  "governance-os-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,6 +1990,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "governance-os-pallet-organizations"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "governance-os-support",
+ "parity-scale-codec",
+ "serde",
+ "sp-runtime",
+]
+
+[[package]]
 name = "governance-os-pallet-tokens"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     'node',
     'pallets/bylaws',
     'pallets/compat',
+    'pallets/organizations',
     'pallets/tokens',
     'primitives',
     'runtime',

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -18,7 +18,7 @@ use governance_os_pallet_tokens::CurrencyDetails;
 use governance_os_primitives::{AccountId, CurrencyId, Role, Signature};
 use governance_os_runtime::{
     AuraConfig, AuraId, BylawsConfig, GenesisConfig, GrandpaConfig, GrandpaId, NativeCurrencyId,
-    SystemConfig, TokensConfig, WASM_BINARY,
+    OrganizationsConfig, SystemConfig, TokensConfig, WASM_BINARY,
 };
 use sc_service::ChainType;
 use sp_core::{sr25519, Pair, Public};
@@ -96,6 +96,9 @@ fn testnet_genesis(
             currency_details: chain_currencies,
         }),
         governance_os_pallet_bylaws: Some(BylawsConfig { roles: chain_roles }),
+        governance_os_pallet_organizations: Some(OrganizationsConfig {
+            organizations: vec![],
+        }),
     }
 }
 

--- a/pallets/bylaws/src/benchmarking.rs
+++ b/pallets/bylaws/src/benchmarking.rs
@@ -55,19 +55,19 @@ benchmarks! {
         let b in 0 .. T::MaxRoles::get();
 
         let (root, target, target_lookup, role) = prepare_benchmark::<T>(b);
-    }: _(RawOrigin::Signed(root), Some(target_lookup), role)
+    }: _(RawOrigin::Signed(root), Some(target_lookup), role.clone())
     verify {
-        assert_eq!(Roles::<T>::get(Some(&target)).iter().any(|&r| r==role), true);
+        assert_eq!(Roles::<T>::get(Some(&target)).iter().any(|r| r.clone() == role), true);
     }
 
     revoke_role {
         let b in 1 .. T::MaxRoles::get();
 
         let (root, target, target_lookup, role) = prepare_benchmark::<T>(b - 1);
-        drop(<Module<T> as RoleManager>::grant_role(Some(&target), role));
-    }: _(RawOrigin::Signed(root), Some(target_lookup), role)
+        drop(<Module<T> as RoleManager>::grant_role(Some(&target), role.clone()));
+    }: _(RawOrigin::Signed(root), Some(target_lookup), role.clone())
     verify {
-        assert_eq!(Roles::<T>::get(Some(&target)).iter().any(|&r| r==role), false);
+        assert_eq!(Roles::<T>::get(Some(&target)).iter().any(|r| r.clone() == role), false);
     }
 }
 

--- a/pallets/bylaws/src/lib.rs
+++ b/pallets/bylaws/src/lib.rs
@@ -182,11 +182,10 @@ impl<T: Trait> RoleManager for Module<T> {
 
     fn has_role(target: &Self::AccountId, role: Self::Role) -> bool {
         Roles::<T>::get(Some(target))
-            .iter()
-            .chain(Roles::<T>::get(None as Option<T::AccountId>).iter())
-            .cloned()
-            .find(|r| {
-                return *r == role || *r == RoleBuilderOf::<T>::root();
+            .into_iter()
+            .chain(Roles::<T>::get(None as Option<T::AccountId>).into_iter())
+            .find(|&r| {
+                return r == role || r == RoleBuilderOf::<T>::root();
             })
             .is_some()
     }

--- a/pallets/bylaws/src/tests/dispatchable.rs
+++ b/pallets/bylaws/src/tests/dispatchable.rs
@@ -30,7 +30,7 @@ fn grant_role() {
             Some(ALICE),
             MockRoles::RemarkOnly,
         ));
-        assert_eq!(Bylaws::has_role(&ALICE, MockRoles::RemarkOnly), true);
+        assert!(Bylaws::has_role(&ALICE, MockRoles::RemarkOnly));
     })
 }
 
@@ -45,6 +45,6 @@ fn revoke_role() {
                 Some(ALICE),
                 MockRoles::RemarkOnly,
             ));
-            assert_eq!(Bylaws::has_role(&ALICE, MockRoles::Root), false);
+            assert!(!Bylaws::has_role(&ALICE, MockRoles::Root));
         })
 }

--- a/pallets/bylaws/src/tests/genesis.rs
+++ b/pallets/bylaws/src/tests/genesis.rs
@@ -27,9 +27,9 @@ fn register_role() {
         .with_role(MockRoles::Root, Some(ALICE))
         .build()
         .execute_with(|| {
-            assert_eq!(Bylaws::has_role(&ALICE, MockRoles::Root), true);
-            assert_eq!(Bylaws::has_role(&BOB, MockRoles::Root), false);
-            assert_eq!(Bylaws::has_role(&ALICE, MockRoles::RemarkOnly), true);
-            assert_eq!(Bylaws::has_role(&BOB, MockRoles::RemarkOnly), true);
+            assert!(Bylaws::has_role(&ALICE, MockRoles::Root));
+            assert!(!Bylaws::has_role(&BOB, MockRoles::Root));
+            assert!(Bylaws::has_role(&ALICE, MockRoles::RemarkOnly));
+            assert!(Bylaws::has_role(&BOB, MockRoles::RemarkOnly));
         })
 }

--- a/pallets/bylaws/src/tests/mock.rs
+++ b/pallets/bylaws/src/tests/mock.rs
@@ -18,23 +18,7 @@ use crate::{
     self as governance_os_pallet_bylaws, // compat with `mock_runtime`
     GenesisConfig,
 };
-use codec::{Decode, Encode};
-use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types};
-use governance_os_support::{
-    acl::Role,
-    impl_enum_default, mock_runtime,
-    testing::{
-        primitives::{AccountId, CurrencyId},
-        AvailableBlockRatio, BlockHashCount, MaximumBlockLength, MaximumBlockWeight, ROOT,
-    },
-};
-use serde::{Deserialize, Serialize};
-use sp_core::H256;
-use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
-    RuntimeDebug,
-};
+use governance_os_support::mock_runtime;
 
 mock_runtime!(Test);
 

--- a/pallets/bylaws/src/tests/role_manager.rs
+++ b/pallets/bylaws/src/tests/role_manager.rs
@@ -25,7 +25,7 @@ fn root_has_all_roles() {
     ExtBuilder::default()
         .alice_as_root()
         .build()
-        .execute_with(|| assert_eq!(Bylaws::has_role(&ALICE, MockRoles::RemarkOnly), true))
+        .execute_with(|| assert!(Bylaws::has_role(&ALICE, MockRoles::RemarkOnly)))
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn has_role_works() {
         .with_role(MockRoles::RemarkOnly, Some(&ALICE))
         .build()
         .execute_with(|| {
-            assert_eq!(Bylaws::has_role(&ALICE, MockRoles::RemarkOnly), true);
-            assert_eq!(Bylaws::has_role(&BOB, MockRoles::RemarkOnly), false);
+            assert!(Bylaws::has_role(&ALICE, MockRoles::RemarkOnly));
+            assert!(!Bylaws::has_role(&BOB, MockRoles::RemarkOnly));
         })
 }

--- a/pallets/compat/src/tests/mock.rs
+++ b/pallets/compat/src/tests/mock.rs
@@ -15,25 +15,7 @@
  */
 
 use crate::{Module, Trait};
-use codec::{Decode, Encode};
-use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types};
-pub use governance_os_support::{
-    acl::Role,
-    impl_enum_default, mock_runtime,
-    testing::{
-        primitives::{AccountId, Balance, CurrencyId},
-        AvailableBlockRatio, BlockHashCount, MaximumBlockLength, MaximumBlockWeight, ALICE, BOB,
-        TEST_TOKEN_ID, TEST_TOKEN_OWNER,
-    },
-    Currencies, ReservableCurrencies,
-};
-use serde::{Deserialize, Serialize};
-use sp_core::H256;
-use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
-    RuntimeDebug,
-};
+use governance_os_support::mock_runtime;
 
 mock_runtime!(Test);
 

--- a/pallets/organizations/Cargo.toml
+++ b/pallets/organizations/Cargo.toml
@@ -22,6 +22,13 @@ serde = { version = "1.0.116", optional = true }
 sp-runtime = { default-features = false, version = '2.0.0' }
 sp-std = { default-features = false, version = "2.0.0" }
 
+[dev-dependencies]
+governance-os-pallet-bylaws = { path = '../bylaws' }
+governance-os-pallet-tokens = { path = '../tokens' }
+serde = '1.0.116'
+sp-core = '2.0.0'
+sp-io = '2.0.0'
+
 [features]
 default = ['std']
 std = [

--- a/pallets/organizations/Cargo.toml
+++ b/pallets/organizations/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+edition = '2018'
+license = 'Apache 2.0'
+name = 'governance-os-pallet-organizations'
+version = '0.1.0'
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+# alias 'parity-scale-code' to 'codec'
+[dependencies.codec]
+default-features = false
+features = ['derive']
+package = 'parity-scale-codec'
+version = '1.3.4'
+
+[dependencies]
+frame-support = { default-features = false, version = '2.0.0' }
+frame-system = { default-features = false, version = '2.0.0' }
+governance-os-support = { default-features = false, path = '../../support' }
+serde = { version = "1.0.116", optional = true }
+sp-runtime = { default-features = false, version = '2.0.0' }
+
+[features]
+default = ['std']
+std = [
+    'codec/std',
+    'frame-support/std',
+    'frame-system/std',
+    'governance-os-support/std',
+    'serde',
+    'sp-runtime/std',
+]

--- a/pallets/organizations/Cargo.toml
+++ b/pallets/organizations/Cargo.toml
@@ -20,6 +20,7 @@ frame-system = { default-features = false, version = '2.0.0' }
 governance-os-support = { default-features = false, path = '../../support' }
 serde = { version = "1.0.116", optional = true }
 sp-runtime = { default-features = false, version = '2.0.0' }
+sp-std = { default-features = false, version = "2.0.0" }
 
 [features]
 default = ['std']
@@ -30,4 +31,5 @@ std = [
     'governance-os-support/std',
     'serde',
     'sp-runtime/std',
+    'sp-std/std',
 ]

--- a/pallets/organizations/Cargo.toml
+++ b/pallets/organizations/Cargo.toml
@@ -24,7 +24,6 @@ sp-std = { default-features = false, version = "2.0.0" }
 
 [dev-dependencies]
 governance-os-pallet-bylaws = { path = '../bylaws' }
-governance-os-pallet-tokens = { path = '../tokens' }
 serde = '1.0.116'
 sp-core = '2.0.0'
 sp-io = '2.0.0'

--- a/pallets/organizations/src/details.rs
+++ b/pallets/organizations/src/details.rs
@@ -18,11 +18,13 @@ use codec::{Decode, Encode};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_runtime::RuntimeDebug;
+use sp_std::prelude::Vec;
 
 /// This structure is used to encode metadata about an organization.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct OrganizationDetails<CurrencyId> {
-    /// Which currency is used to represent voting shares.
-    pub voting_currency: CurrencyId,
+pub struct OrganizationDetails<AccountId> {
+    /// A set of accounts that have access to the `apply_as` function
+    /// of an organization.
+    pub executors: Vec<AccountId>,
 }

--- a/pallets/organizations/src/details.rs
+++ b/pallets/organizations/src/details.rs
@@ -27,4 +27,15 @@ pub struct OrganizationDetails<AccountId> {
     /// A set of accounts that have access to the `apply_as` function
     /// of an organization.
     pub executors: Vec<AccountId>,
+
+    /// A set of accounts that can change an organization's parameters.
+    pub managers: Vec<AccountId>,
+}
+
+impl<AccountId: Ord> OrganizationDetails<AccountId> {
+    /// Sort all the vectors inside the strutcture.
+    pub fn sort(&mut self) {
+        self.executors.sort();
+        self.managers.sort();
+    }
 }

--- a/pallets/organizations/src/details.rs
+++ b/pallets/organizations/src/details.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use codec::{Decode, Encode};
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+use sp_runtime::RuntimeDebug;
+
+/// This structure is used to encode metadata about an organization.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct OrganizationDetails<CurrencyId> {
+    /// Which currency is used to represent voting shares.
+    pub voting_currency: CurrencyId,
+}

--- a/pallets/organizations/src/lib.rs
+++ b/pallets/organizations/src/lib.rs
@@ -16,26 +16,42 @@
 
 //! This pallet bundles together the `bylaws` and `tokens` ones to create and
 //! manage decentralized autonomous organizations.
+//! Note that we give an account id to every organization created, this opens up
+//! the possibility to send some funds to an organization and have it spend the funds
+//! itself with no additional logic.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use frame_support::{decl_error, decl_event, decl_module, decl_storage};
+use frame_support::{
+    decl_error, decl_event, decl_module, decl_storage,
+    dispatch::{Dispatchable, Parameter},
+    weights::GetDispatchInfo,
+};
 use governance_os_support::{acl::RoleManager, Currencies};
-use sp_runtime::{traits::AccountIdConversion, ModuleId};
+use sp_runtime::{traits::AccountIdConversion, DispatchResult, ModuleId};
+use sp_std::boxed::Box;
 
 mod details;
 use details::OrganizationDetails;
 
 pub trait RoleBuilder {
+    type OrganizationId;
     type Role;
 
     /// Role for creating new organizations.
     fn create_organizations() -> Self::Role;
+
+    /// This role gives the ability to execute calls as if they came
+    /// from the organization address.
+    fn apply_as_organization(org_id: Self::OrganizationId) -> Self::Role;
 }
 
 pub trait Trait: frame_system::Trait {
     /// Because this pallet emits events, it depends on the runtime's definition of an event.
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+
+    /// Calls triggered from an organization.
+    type Call: Parameter + GetDispatchInfo + Dispatchable<Origin = Self::Origin>;
 
     /// Since orgnizations can use different tokens to represent voting shares we need this
     /// type to be specified so that we can access all of the runtime's currencies.
@@ -47,7 +63,10 @@ pub trait Trait: frame_system::Trait {
     /// This pallet relies on roles associated to a specific metadata so we need the runtime
     /// to provide some helper functions to build those so that we can keep the role definition
     /// code modular.
-    type RoleBuilder: RoleBuilder<Role = <RoleManagerOf<Self> as RoleManager>::Role>;
+    type RoleBuilder: RoleBuilder<
+        OrganizationId = Self::AccountId,
+        Role = <RoleManagerOf<Self> as RoleManager>::Role,
+    >;
 }
 
 type CurrencyIdOf<T> =
@@ -71,6 +90,8 @@ decl_event!(
     {
         /// An organization was created with the following parameters. \[org. address, details\]
         OrganizationCreated(AccountId, OrganizationDetails),
+        /// An organization executed a call. \[org. address, result\]
+        OrganizationExecuted(AccountId, DispatchResult),
     }
 );
 
@@ -90,16 +111,25 @@ decl_module! {
         /// the organization's address.
         #[weight = 0]
         fn create(origin, details: OrganizationDetails<CurrencyIdOf<T>>) {
-            RoleManagerOf::<T>::ensure_has_role(origin, RoleBuilderOf::<T>::create_organizations())?;
+            let who = RoleManagerOf::<T>::ensure_has_role(origin, RoleBuilderOf::<T>::create_organizations())?;
 
             let counter = Self::created_organizations();
             let new_counter = counter.checked_add(1).ok_or(Error::<T>::CreatedOrganizationsOverflow)?;
             let org_id: T::AccountId = ORGS_MODULE_ID.into_sub_account(counter);
 
-            // TODO: actually create the stuff
+            RoleManagerOf::<T>::grant_role(Some(&who), RoleBuilderOf::<T>::apply_as_organization(org_id.clone()))?;
             CreatedOrganizations::put(new_counter);
 
             Self::deposit_event(RawEvent::OrganizationCreated(org_id, details));
+        }
+
+        /// Trigger a call as if it came from the organization itself.
+        #[weight = 0]
+        fn apply_as(origin, org_id: T::AccountId, call: Box<<T as Trait>::Call>) {
+            RoleManagerOf::<T>::ensure_has_role(origin, RoleBuilderOf::<T>::apply_as_organization(org_id.clone()))?;
+
+            let res = call.dispatch(frame_system::RawOrigin::Signed(org_id.clone()).into());
+            Self::deposit_event(RawEvent::OrganizationExecuted(org_id, res.map(|_| ()).map_err(|e| e.error)));
         }
     }
 }

--- a/pallets/organizations/src/lib.rs
+++ b/pallets/organizations/src/lib.rs
@@ -218,6 +218,14 @@ impl<T: Trait> Module<T> {
                 RoleBuilderOf::<T>::manage_organization(&org_id),
             ));
         });
+        drop(RoleManagerOf::<T>::grant_role(
+            Some(&org_id),
+            RoleBuilderOf::<T>::apply_as_organization(&org_id),
+        ));
+        drop(RoleManagerOf::<T>::grant_role(
+            Some(&org_id),
+            RoleBuilderOf::<T>::manage_organization(&org_id),
+        ));
         Parameters::<T>::insert(&org_id, details.clone());
 
         Self::deposit_event(RawEvent::OrganizationCreated(org_id, details));

--- a/pallets/organizations/src/lib.rs
+++ b/pallets/organizations/src/lib.rs
@@ -32,6 +32,8 @@ use sp_runtime::{traits::AccountIdConversion, DispatchResult, ModuleId};
 use sp_std::boxed::Box;
 
 mod details;
+#[cfg(test)]
+mod tests;
 use details::OrganizationDetails;
 
 pub trait RoleBuilder {

--- a/pallets/organizations/src/lib.rs
+++ b/pallets/organizations/src/lib.rs
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! This pallet bundles together the `bylaws` and `tokens` ones to create and
+//! manage decentralized autonomous organizations.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::{decl_error, decl_event, decl_module, decl_storage};
+use governance_os_support::{acl::RoleManager, Currencies};
+use sp_runtime::{traits::AccountIdConversion, ModuleId};
+
+mod details;
+use details::OrganizationDetails;
+
+pub trait RoleBuilder {
+    type Role;
+
+    /// Role for creating new organizations.
+    fn create_organizations() -> Self::Role;
+}
+
+pub trait Trait: frame_system::Trait {
+    /// Because this pallet emits events, it depends on the runtime's definition of an event.
+    type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+
+    /// Since orgnizations can use different tokens to represent voting shares we need this
+    /// type to be specified so that we can access all of the runtime's currencies.
+    type Currencies: Currencies<Self::AccountId>;
+
+    /// Pallet that is in charge of managing the roles based ACL.
+    type RoleManager: RoleManager<AccountId = Self::AccountId>;
+
+    /// This pallet relies on roles associated to a specific metadata so we need the runtime
+    /// to provide some helper functions to build those so that we can keep the role definition
+    /// code modular.
+    type RoleBuilder: RoleBuilder<Role = <RoleManagerOf<Self> as RoleManager>::Role>;
+}
+
+type CurrencyIdOf<T> =
+    <<T as Trait>::Currencies as Currencies<<T as frame_system::Trait>::AccountId>>::CurrencyId;
+type RoleBuilderOf<T> = <T as Trait>::RoleBuilder;
+type RoleManagerOf<T> = <T as Trait>::RoleManager;
+
+const ORGS_MODULE_ID: ModuleId = ModuleId(*b"gos/orgs");
+
+decl_storage! {
+    trait Store for Module<T: Trait> as Organizations {
+        pub CreatedOrganizations get(fn created_organizations): u32 = 0;
+    }
+}
+
+decl_event!(
+    pub enum Event<T>
+    where
+        AccountId = <T as frame_system::Trait>::AccountId,
+        OrganizationDetails = OrganizationDetails<CurrencyIdOf<T>>,
+    {
+        /// An organization was created with the following parameters. \[org. address, details\]
+        OrganizationCreated(AccountId, OrganizationDetails),
+    }
+);
+
+decl_error! {
+    pub enum Error for Module<T: Trait> {
+        /// We have created the maximum number of organizations, a runtime upgrade may
+        /// be necessary.
+        CreatedOrganizationsOverflow,
+    }
+}
+
+decl_module! {
+    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        fn deposit_event() = default;
+
+        /// Create an organization with the given parameters. An event will be triggered with
+        /// the organization's address.
+        #[weight = 0]
+        fn create(origin, details: OrganizationDetails<CurrencyIdOf<T>>) {
+            RoleManagerOf::<T>::ensure_has_role(origin, RoleBuilderOf::<T>::create_organizations())?;
+
+            let counter = Self::created_organizations();
+            let new_counter = counter.checked_add(1).ok_or(Error::<T>::CreatedOrganizationsOverflow)?;
+            let org_id: T::AccountId = ORGS_MODULE_ID.into_sub_account(counter);
+
+            // TODO: actually create the stuff
+            CreatedOrganizations::put(new_counter);
+
+            Self::deposit_event(RawEvent::OrganizationCreated(org_id, details));
+        }
+    }
+}

--- a/pallets/organizations/src/tests/details.rs
+++ b/pallets/organizations/src/tests/details.rs
@@ -15,11 +15,11 @@
  */
 
 use crate::OrganizationDetails;
-use governance_os_support::testing::{primitives::AccountId, ALICE, BOB};
+use governance_os_support::testing::{ALICE, BOB};
 
 #[test]
 fn sort() {
-    let details = OrganizationDetails {
+    let mut details = OrganizationDetails {
         executors: vec![BOB, ALICE],
         managers: vec![BOB, ALICE],
     };

--- a/pallets/organizations/src/tests/details.rs
+++ b/pallets/organizations/src/tests/details.rs
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::OrganizationDetails;
+use governance_os_support::testing::{primitives::AccountId, ALICE, BOB};
+
+#[test]
+fn sort() {
+    let details = OrganizationDetails {
+        executors: vec![BOB, ALICE],
+        managers: vec![BOB, ALICE],
+    };
+    details.sort();
+    assert_eq!(details.executors, vec![ALICE, BOB]);
+    assert_eq!(details.managers, vec![ALICE, BOB]);
+}

--- a/pallets/organizations/src/tests/dispatchable.rs
+++ b/pallets/organizations/src/tests/dispatchable.rs
@@ -61,6 +61,16 @@ fn create_increments_counter_and_save_details_and_configure_roles() {
                 &EVE,
                 MockRoles::manage_organization(&org_id)
             ));
+
+            // Org ID is granted roles as well
+            assert!(Bylaws::has_role(
+                &org_id,
+                MockRoles::apply_as_organization(&org_id)
+            ));
+            assert!(Bylaws::has_role(
+                &org_id,
+                MockRoles::manage_organization(&org_id)
+            ));
         })
 }
 

--- a/pallets/organizations/src/tests/dispatchable.rs
+++ b/pallets/organizations/src/tests/dispatchable.rs
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::mock::{Bylaws, Call, ExtBuilder, MockRoles, Organizations};
+use crate::{OrganizationDetails, RoleBuilder};
+use frame_support::{assert_noop, assert_ok};
+use frame_system::RawOrigin;
+use governance_os_support::{
+    acl::{AclError, RoleManager},
+    testing::{ALICE, BOB, CHARLIE, EVE},
+};
+
+#[test]
+fn create_increments_counter_and_save_details_and_configure_roles() {
+    ExtBuilder::default()
+        .alice_can_create_orgs()
+        .build()
+        .execute_with(|| {
+            assert_ok!(Organizations::create(
+                RawOrigin::Signed(ALICE).into(),
+                OrganizationDetails {
+                    // We intentionally make it unsorted for the test
+                    executors: vec![CHARLIE, BOB],
+                    managers: vec![EVE, ALICE],
+                }
+            ));
+            assert_eq!(Organizations::counter(), 1);
+
+            let org_id = Organizations::org_id_for(0);
+
+            let params = Organizations::parameters(org_id);
+            assert_eq!(params.executors.as_slice(), [BOB, CHARLIE]);
+            assert_eq!(params.managers.as_slice(), [ALICE, EVE]);
+
+            assert!(Bylaws::has_role(
+                &CHARLIE,
+                MockRoles::apply_as_organization(&org_id)
+            ));
+            assert!(Bylaws::has_role(
+                &BOB,
+                MockRoles::apply_as_organization(&org_id)
+            ));
+            assert!(Bylaws::has_role(
+                &ALICE,
+                MockRoles::manage_organization(&org_id)
+            ));
+            assert!(Bylaws::has_role(
+                &EVE,
+                MockRoles::manage_organization(&org_id)
+            ));
+        })
+}
+
+#[test]
+fn apply_as() {
+    ExtBuilder::default()
+        .alice_can_create_orgs()
+        .build()
+        .execute_with(|| {
+            assert_ok!(Organizations::create(
+                RawOrigin::Signed(ALICE).into(),
+                OrganizationDetails {
+                    executors: vec![ALICE],
+                    managers: vec![],
+                }
+            ));
+            assert_ok!(Organizations::apply_as(
+                RawOrigin::Signed(ALICE).into(),
+                Organizations::org_id_for(0),
+                Box::new(Call::System(frame_system::Call::remark(vec![]))),
+            ));
+        })
+}
+
+#[test]
+fn mutate_save_details_and_update_roles() {
+    ExtBuilder::default()
+        .alice_can_create_orgs()
+        .build()
+        .execute_with(|| {
+            assert_ok!(Organizations::create(
+                RawOrigin::Signed(ALICE).into(),
+                OrganizationDetails {
+                    executors: vec![ALICE, BOB],
+                    managers: vec![ALICE, BOB],
+                }
+            ));
+            let org_id = Organizations::org_id_for(0);
+            assert_ok!(Organizations::mutate(
+                RawOrigin::Signed(ALICE).into(),
+                org_id,
+                OrganizationDetails {
+                    executors: vec![ALICE, CHARLIE],
+                    managers: vec![ALICE, CHARLIE]
+                },
+            ));
+
+            let params = Organizations::parameters(org_id);
+            assert_eq!(params.executors.as_slice(), [ALICE, CHARLIE]);
+            assert_eq!(params.managers.as_slice(), [ALICE, CHARLIE]);
+
+            // BOB lost permissions
+            assert!(!Bylaws::has_role(
+                &BOB,
+                MockRoles::apply_as_organization(&org_id)
+            ));
+            assert!(!Bylaws::has_role(
+                &BOB,
+                MockRoles::manage_organization(&org_id)
+            ));
+
+            // ALICE kept them
+            assert!(Bylaws::has_role(
+                &ALICE,
+                MockRoles::apply_as_organization(&org_id)
+            ));
+            assert!(Bylaws::has_role(
+                &ALICE,
+                MockRoles::manage_organization(&org_id)
+            ));
+
+            // CHARLIE won them
+            assert!(Bylaws::has_role(
+                &CHARLIE,
+                MockRoles::apply_as_organization(&org_id)
+            ));
+            assert!(Bylaws::has_role(
+                &CHARLIE,
+                MockRoles::manage_organization(&org_id)
+            ));
+        })
+}
+
+#[test]
+fn create_fail_if_not_corect_role() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            Organizations::create(
+                RawOrigin::Signed(ALICE).into(),
+                OrganizationDetails::default()
+            ),
+            AclError::MissingRole
+        );
+    })
+}
+
+#[test]
+fn apply_as_fail_if_not_correct_role() {
+    ExtBuilder::default()
+        .with_default_orgs(1)
+        .build()
+        .execute_with(|| {
+            assert_noop!(
+                Organizations::apply_as(
+                    RawOrigin::Signed(ALICE).into(),
+                    Organizations::org_id_for(0),
+                    Box::new(Call::System(frame_system::Call::remark(vec![])))
+                ),
+                AclError::MissingRole
+            );
+        })
+}
+
+#[test]
+fn mutate_fail_if_not_correct_role() {
+    ExtBuilder::default()
+        .with_default_orgs(1)
+        .build()
+        .execute_with(|| {
+            assert_noop!(
+                Organizations::mutate(
+                    RawOrigin::Signed(ALICE).into(),
+                    Organizations::org_id_for(0),
+                    OrganizationDetails::default()
+                ),
+                AclError::MissingRole
+            );
+        })
+}

--- a/pallets/organizations/src/tests/genesis.rs
+++ b/pallets/organizations/src/tests/genesis.rs
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::mock::{ExtBuilder, Organizations, Test};
+use crate::Parameters;
+use frame_support::StorageMap;
+
+#[test]
+fn create_organizations_and_increment_counter() {
+    ExtBuilder::default()
+        .with_default_orgs(3)
+        .build()
+        .execute_with(|| {
+            assert_eq!(Organizations::counter(), 3);
+            assert!(Parameters::<Test>::contains_key(Organizations::org_id_for(
+                0
+            )));
+            assert!(Parameters::<Test>::contains_key(Organizations::org_id_for(
+                1
+            )));
+            assert!(Parameters::<Test>::contains_key(Organizations::org_id_for(
+                2
+            )));
+            assert!(!Parameters::<Test>::contains_key(
+                Organizations::org_id_for(3)
+            ));
+        })
+}

--- a/pallets/organizations/src/tests/meta.rs
+++ b/pallets/organizations/src/tests/meta.rs
@@ -14,8 +14,17 @@
  * limitations under the License.
  */
 
-pub mod details;
-pub mod dispatchable;
-pub mod genesis;
-pub mod meta;
-pub mod mock;
+use super::mock::Organizations;
+use sp_std::collections::btree_set::BTreeSet;
+
+#[test]
+fn org_ids_are_different() {
+    let mut all_ids = BTreeSet::new();
+
+    assert!(Organizations::org_id_for(1) != Organizations::org_id_for(2));
+    for i in 0..100 {
+        let id = Organizations::org_id_for(i);
+        assert!(!all_ids.contains(&id));
+        all_ids.insert(id);
+    }
+}

--- a/pallets/organizations/src/tests/mock.rs
+++ b/pallets/organizations/src/tests/mock.rs
@@ -34,12 +34,12 @@ impl RoleBuilder for MockRoles {
         MockRoles::CreateOrganizations
     }
 
-    fn apply_as_organization(org_id: Self::OrganizationId) -> Self::Role {
-        MockRoles::ApplyAsOrganization(org_id)
+    fn apply_as_organization(org_id: &Self::OrganizationId) -> Self::Role {
+        MockRoles::ApplyAsOrganization(*org_id)
     }
 
-    fn manage_organization(org_id: Self::OrganizationId) -> Self::Role {
-        MockRoles::ManageOrganization(org_id)
+    fn manage_organization(org_id: &Self::OrganizationId) -> Self::Role {
+        MockRoles::ManageOrganization(*org_id)
     }
 }
 

--- a/pallets/organizations/src/tests/mock.rs
+++ b/pallets/organizations/src/tests/mock.rs
@@ -24,7 +24,6 @@ impl Trait for Test {
     type Call = Call;
     type RoleManager = Bylaws;
     type RoleBuilder = MockRoles;
-    type Currencies = Tokens;
 }
 
 impl RoleBuilder for MockRoles {
@@ -37,6 +36,10 @@ impl RoleBuilder for MockRoles {
 
     fn apply_as_organization(org_id: Self::OrganizationId) -> Self::Role {
         MockRoles::ApplyAsOrganization(org_id)
+    }
+
+    fn manage_organization(org_id: Self::OrganizationId) -> Self::Role {
+        MockRoles::ManageOrganization(org_id)
     }
 }
 

--- a/pallets/organizations/src/tests/mock.rs
+++ b/pallets/organizations/src/tests/mock.rs
@@ -15,9 +15,9 @@
  */
 
 use crate::{Module, RoleBuilder, Trait};
-use governance_os_support::mock_runtime_with_currencies;
+use governance_os_support::mock_runtime;
 
-mock_runtime_with_currencies!(Test);
+mock_runtime!(Test);
 
 impl Trait for Test {
     type Event = ();

--- a/pallets/organizations/src/tests/mock.rs
+++ b/pallets/organizations/src/tests/mock.rs
@@ -15,25 +15,7 @@
  */
 
 use crate::{Module, RoleBuilder, Trait};
-use codec::{Decode, Encode};
-use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types};
-pub use governance_os_support::{
-    acl::Role,
-    impl_enum_default, mock_runtime, mock_runtime_with_currencies,
-    testing::{
-        primitives::{AccountId, Balance, CurrencyId},
-        AvailableBlockRatio, BlockHashCount, MaximumBlockLength, MaximumBlockWeight, ALICE, BOB,
-        TEST_TOKEN_ID, TEST_TOKEN_OWNER,
-    },
-    Currencies, ReservableCurrencies,
-};
-use serde::{Deserialize, Serialize};
-use sp_core::H256;
-use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
-    RuntimeDebug,
-};
+use governance_os_support::mock_runtime_with_currencies;
 
 mock_runtime_with_currencies!(Test);
 

--- a/pallets/organizations/src/tests/mock.rs
+++ b/pallets/organizations/src/tests/mock.rs
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::{Module, RoleBuilder, Trait};
+use codec::{Decode, Encode};
+use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types};
+pub use governance_os_support::{
+    acl::Role,
+    impl_enum_default, mock_runtime, mock_runtime_with_currencies,
+    testing::{
+        primitives::{AccountId, Balance, CurrencyId},
+        AvailableBlockRatio, BlockHashCount, MaximumBlockLength, MaximumBlockWeight, ALICE, BOB,
+        TEST_TOKEN_ID, TEST_TOKEN_OWNER,
+    },
+    Currencies, ReservableCurrencies,
+};
+use serde::{Deserialize, Serialize};
+use sp_core::H256;
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    RuntimeDebug,
+};
+
+mock_runtime_with_currencies!(Test);
+
+impl Trait for Test {
+    type Event = ();
+    type Call = Call;
+    type RoleManager = Bylaws;
+    type RoleBuilder = MockRoles;
+    type Currencies = Tokens;
+}
+
+impl RoleBuilder for MockRoles {
+    type OrganizationId = AccountId;
+    type Role = MockRoles;
+
+    fn create_organizations() -> Self::Role {
+        MockRoles::CreateOrganizations
+    }
+
+    fn apply_as_organization(org_id: Self::OrganizationId) -> Self::Role {
+        MockRoles::ApplyAsOrganization(org_id)
+    }
+}
+
+pub type Organizations = Module<Test>;

--- a/pallets/organizations/src/tests/mod.rs
+++ b/pallets/organizations/src/tests/mod.rs
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod mock;

--- a/pallets/tokens/src/tests/adapter.rs
+++ b/pallets/tokens/src/tests/adapter.rs
@@ -23,6 +23,10 @@ use frame_support::{
         SignedImbalance, WithdrawReason,
     },
 };
+use governance_os_support::{
+    testing::{ALICE, BOB, TEST_TOKEN_ID},
+    Currencies, ReservableCurrencies,
+};
 
 #[test]
 fn total_issuance() {

--- a/pallets/tokens/src/tests/currencies.rs
+++ b/pallets/tokens/src/tests/currencies.rs
@@ -20,6 +20,10 @@ use frame_support::{
     traits::BalanceStatus,
     {assert_noop, assert_ok},
 };
+use governance_os_support::{
+    testing::{primitives::AccountId, ALICE, BOB, TEST_TOKEN_ID, TEST_TOKEN_OWNER},
+    Currencies, ReservableCurrencies,
+};
 
 #[test]
 fn transfer_should_work() {

--- a/pallets/tokens/src/tests/dispatchable.rs
+++ b/pallets/tokens/src/tests/dispatchable.rs
@@ -19,7 +19,8 @@ use crate::{CurrencyDetails, Error, RoleBuilder};
 use frame_support::{assert_noop, assert_ok};
 use governance_os_support::{
     acl::{AclError, RoleManager},
-    testing::ALICE,
+    testing::{ALICE, BOB, TEST_TOKEN_ID, TEST_TOKEN_OWNER},
+    Currencies,
 };
 
 #[test]

--- a/pallets/tokens/src/tests/genesis.rs
+++ b/pallets/tokens/src/tests/genesis.rs
@@ -16,7 +16,11 @@
 
 use super::mock::*;
 use crate::RoleBuilder;
-use governance_os_support::acl::RoleManager;
+use governance_os_support::{
+    acl::RoleManager,
+    testing::{ALICE, BOB, TEST_TOKEN_ID, TEST_TOKEN_OWNER},
+    Currencies,
+};
 
 #[test]
 fn set_storage_correctly() {

--- a/pallets/tokens/src/tests/misc.rs
+++ b/pallets/tokens/src/tests/misc.rs
@@ -17,6 +17,10 @@
 use super::mock::*;
 use frame_support::{assert_ok, StorageMap};
 use frame_system::Account;
+use governance_os_support::{
+    testing::{primitives::AccountId, ALICE, BOB, TEST_TOKEN_ID},
+    Currencies,
+};
 
 #[test]
 fn kill_currency_if_balance_down_to_zero() {

--- a/pallets/tokens/src/tests/mock.rs
+++ b/pallets/tokens/src/tests/mock.rs
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
-use crate::{CurrencyDetails, GenesisConfig, Module, NativeCurrencyAdapter, RoleBuilder, Trait};
+use crate::{
+    self as governance_os_pallet_tokens, // Compat with the mock_runtime_with_currencies macro
+    CurrencyDetails,
+    GenesisConfig,
+    NativeCurrencyAdapter,
+};
 use codec::{Decode, Encode};
 use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types};
 pub use governance_os_support::{
     acl::Role,
-    impl_enum_default, mock_runtime,
+    impl_enum_default, mock_runtime, mock_runtime_with_currencies,
     testing::{
         primitives::{AccountId, Balance, CurrencyId},
         AvailableBlockRatio, BlockHashCount, MaximumBlockLength, MaximumBlockWeight, ALICE, BOB,
@@ -35,40 +40,10 @@ use sp_runtime::{
     RuntimeDebug,
 };
 
-mock_runtime!(Test, crate::AccountData<CurrencyId, Balance>);
-
-impl RoleBuilder for MockRoles {
-    type CurrencyId = CurrencyId;
-    type Role = Self;
-
-    fn transfer_currency(id: CurrencyId) -> Self {
-        Self::TransferCurrency(id)
-    }
-
-    fn manage_currency(id: CurrencyId) -> Self {
-        Self::ManageCurrency(id)
-    }
-
-    fn create_currencies() -> Self {
-        Self::CreateCurrencies
-    }
-}
-
-impl Trait for Test {
-    type Event = ();
-    type CurrencyId = CurrencyId;
-    type Balance = Balance;
-    type WeightInfo = ();
-    type AccountStore = System;
-    type RoleManager = Bylaws;
-    type RoleBuilder = MockRoles;
-}
-
+mock_runtime_with_currencies!(Test);
 parameter_types! {
     pub const GetTestTokenId: CurrencyId = TEST_TOKEN_ID;
 }
-
-pub type Tokens = Module<Test>;
 pub type TokensCurrencyAdapter = NativeCurrencyAdapter<Test, GetTestTokenId>;
 
 pub struct ExtBuilder {

--- a/pallets/tokens/src/tests/mock.rs
+++ b/pallets/tokens/src/tests/mock.rs
@@ -20,24 +20,9 @@ use crate::{
     GenesisConfig,
     NativeCurrencyAdapter,
 };
-use codec::{Decode, Encode};
-use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types};
-pub use governance_os_support::{
-    acl::Role,
-    impl_enum_default, mock_runtime, mock_runtime_with_currencies,
-    testing::{
-        primitives::{AccountId, Balance, CurrencyId},
-        AvailableBlockRatio, BlockHashCount, MaximumBlockLength, MaximumBlockWeight, ALICE, BOB,
-        TEST_TOKEN_ID, TEST_TOKEN_OWNER,
-    },
-    Currencies, ReservableCurrencies,
-};
-use serde::{Deserialize, Serialize};
-use sp_core::H256;
-use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
-    RuntimeDebug,
+use governance_os_support::{
+    mock_runtime_with_currencies,
+    testing::{ALICE, BOB, TEST_TOKEN_ID, TEST_TOKEN_OWNER},
 };
 
 mock_runtime_with_currencies!(Test);

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -17,6 +17,7 @@ version = '1.3.4'
 [dependencies]
 frame-system = { version = '2.0.0', default-features = false }
 governance-os-pallet-bylaws = { path = '../pallets/bylaws', default-features = false }
+governance-os-pallet-organizations = { path = '../pallets/organizations', default-features = false }
 governance-os-pallet-tokens = { path = '../pallets/tokens', default-features = false }
 governance-os-support = { path = '../support', default-features = false }
 serde = { version = '1.0.116', optional = true }
@@ -31,6 +32,7 @@ std = [
 	'codec/std',
 	'frame-system/std',
 	'governance-os-pallet-bylaws/std',
+	'governance-os-pallet-organizations/std',
 	'governance-os-pallet-tokens/std',
 	'governance-os-support/std',
 	'serde',

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -69,11 +69,14 @@ pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 pub type Block = generic::Block<Header, OpaqueExtrinsic>;
 
 /// The different roles supported by the runtime.
-#[derive(Encode, Decode, RuntimeDebug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Encode, Decode, RuntimeDebug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum Role {
+    ApplyAsOrganization(AccountId),
     CreateCurrencies,
+    CreateOrganizations,
     ManageCurrency(CurrencyId),
+    ManageOrganization(AccountId),
     ManageRoles,
     Root,
     TransferCurrency(CurrencyId),
@@ -107,5 +110,21 @@ impl governance_os_pallet_bylaws::RoleBuilder for Role {
 
     fn root() -> Role {
         Role::Root
+    }
+}
+impl governance_os_pallet_organizations::RoleBuilder for Role {
+    type OrganizationId = AccountId;
+    type Role = Role;
+
+    fn create_organizations() -> Role {
+        Role::CreateOrganizations
+    }
+
+    fn apply_as_organization(org_id: &AccountId) -> Role {
+        Role::ApplyAsOrganization(org_id.clone())
+    }
+
+    fn manage_organization(org_id: &AccountId) -> Role {
+        Role::ManageOrganization(org_id.clone())
     }
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -26,6 +26,7 @@ frame-system-benchmarking = { default-features = false, version = '2.0.0', optio
 frame-system-rpc-runtime-api = { version = '2.0.0', default-features = false }
 governance-os-pallet-bylaws = { default-features = false, path = '../pallets/bylaws' }
 governance-os-pallet-compat = { default-features = false, path = '../pallets/compat' }
+governance-os-pallet-organizations = { default-features = false, path = '../pallets/organizations' }
 governance-os-pallet-tokens = { default-features = false, path = '../pallets/tokens' }
 governance-os-primitives = { default-features = false, path = '../primitives' }
 governance-os-support = { default-features = false, path = '../support' }
@@ -59,6 +60,7 @@ std = [
     'frame-system-rpc-runtime-api/std',
     'governance-os-pallet-bylaws/std',
     'governance-os-pallet-compat/std',
+    'governance-os-pallet-organizations/std',
     'governance-os-pallet-tokens/std',
     'governance-os-primitives/std',
     'governance-os-support/std',

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -79,6 +79,7 @@ construct_runtime!(
 
         // dOrgs
         Bylaws: governance_os_pallet_bylaws::{Module, Call, Storage, Config<T>, Event<T>},
+        Organizations: governance_os_pallet_organizations::{Module, Call, Storage, Config<T>, Event<T>},
     }
 );
 

--- a/runtime/src/pallets_dorgs.rs
+++ b/runtime/src/pallets_dorgs.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::{Event, Runtime};
+use crate::{Bylaws, Call, Event, Runtime};
 use frame_support::parameter_types;
 use governance_os_primitives::Role;
 
@@ -27,5 +27,12 @@ impl governance_os_pallet_bylaws::Trait for Runtime {
     type Role = Role;
     type WeightInfo = ();
     type MaxRoles = MaxRoles;
+    type RoleBuilder = Role;
+}
+
+impl governance_os_pallet_organizations::Trait for Runtime {
+    type Event = Event;
+    type Call = Call;
+    type RoleManager = Bylaws;
     type RoleBuilder = Role;
 }

--- a/support/src/acl.rs
+++ b/support/src/acl.rs
@@ -41,7 +41,7 @@ impl Into<DispatchError> for AclError {
 
 /// This defines a role. Roles can be granted to any number of addresses, frozen
 /// (denied for anybody) and granted to everybody at once.
-pub trait Role: Parameter + Member + Copy + MaybeSerializeDeserialize + Ord {}
+pub trait Role: Parameter + Member + MaybeSerializeDeserialize + Ord {}
 
 /// This trait can be implemented by a pallet to expose an interface for other pallets to
 /// manage their own role based access control features.

--- a/support/src/testing.rs
+++ b/support/src/testing.rs
@@ -111,6 +111,8 @@ macro_rules! mock_runtime {
             CreateCurrencies,
             TransferCurrency(CurrencyId),
             ManageCurrency(CurrencyId),
+            CreateOrganizations,
+            ApplyAsOrganization(AccountId),
         }
         impl Role for MockRoles {}
         impl_enum_default!(MockRoles, RemarkOnly);
@@ -142,4 +144,41 @@ macro_rules! mock_runtime {
         pub type Bylaws = governance_os_pallet_bylaws::Module<Test>;
         pub type System = frame_system::Module<Test>;
     };
+}
+
+#[macro_export]
+/// This is an extension of the macro `mock_runtime` to add support for the `tokens` macro.
+macro_rules! mock_runtime_with_currencies {
+    ($runtime:tt) => {
+        mock_runtime!($runtime, governance_os_pallet_tokens::AccountData<CurrencyId, Balance>);
+
+        impl governance_os_pallet_tokens::RoleBuilder for MockRoles {
+            type CurrencyId = CurrencyId;
+            type Role = Self;
+
+            fn transfer_currency(id: CurrencyId) -> Self {
+                Self::TransferCurrency(id)
+            }
+
+            fn manage_currency(id: CurrencyId) -> Self {
+                Self::ManageCurrency(id)
+            }
+
+            fn create_currencies() -> Self {
+                Self::CreateCurrencies
+            }
+        }
+
+        impl governance_os_pallet_tokens::Trait for Test {
+            type Event = ();
+            type CurrencyId = CurrencyId;
+            type Balance = Balance;
+            type WeightInfo = ();
+            type AccountStore = System;
+            type RoleManager = Bylaws;
+            type RoleBuilder = MockRoles;
+        }
+
+        pub type Tokens = governance_os_pallet_tokens::Module<Test>;
+    }
 }

--- a/support/src/testing.rs
+++ b/support/src/testing.rs
@@ -20,10 +20,12 @@ use frame_support::{parameter_types, weights::Weight};
 use sp_runtime::Perbill;
 
 pub const ROOT: primitives::AccountId = 0;
-pub const ALICE: primitives::AccountId = 1;
-pub const BOB: primitives::AccountId = 2;
-pub const TEST_TOKEN_ID: primitives::CurrencyId = 3;
-pub const TEST_TOKEN_OWNER: primitives::AccountId = 4;
+pub const TEST_TOKEN_ID: primitives::CurrencyId = 1;
+pub const TEST_TOKEN_OWNER: primitives::AccountId = 2;
+pub const ALICE: primitives::AccountId = 3;
+pub const BOB: primitives::AccountId = 4;
+pub const CHARLIE: primitives::AccountId = 5;
+pub const EVE: primitives::AccountId = 6;
 
 parameter_types! {
     pub const BlockHashCount: u64 = 250;
@@ -131,6 +133,7 @@ macro_rules! mock_runtime {
             ManageCurrency(CurrencyId),
             CreateOrganizations,
             ApplyAsOrganization(AccountId),
+            ManageOrganization(AccountId),
         }
         impl Role for MockRoles {}
         impl_enum_default!(MockRoles, RemarkOnly);

--- a/support/src/testing.rs
+++ b/support/src/testing.rs
@@ -35,7 +35,7 @@ parameter_types! {
 }
 
 pub mod primitives {
-    pub type AccountId = u64;
+    pub type AccountId = u128;
     pub type Balance = u64;
     pub type CurrencyId = u8;
 }

--- a/support/src/testing.rs
+++ b/support/src/testing.rs
@@ -51,6 +51,24 @@ macro_rules! mock_runtime {
     };
 
     ($runtime:tt, $account_data:ty) => {
+        use codec::{Decode, Encode};
+        use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types};
+        use governance_os_support::{
+            acl::Role,
+            impl_enum_default,
+            testing::{
+                primitives::{AccountId, CurrencyId},
+                AvailableBlockRatio, BlockHashCount, MaximumBlockLength, MaximumBlockWeight, ROOT,
+            },
+        };
+        use serde::{Deserialize, Serialize};
+        use sp_core::H256;
+        use sp_runtime::{
+            testing::Header,
+            traits::{BlakeTwo256, IdentityLookup},
+            RuntimeDebug,
+        };
+
         #[derive(Clone, Eq, PartialEq, RuntimeDebug)]
         pub struct $runtime;
 
@@ -150,6 +168,8 @@ macro_rules! mock_runtime {
 /// This is an extension of the macro `mock_runtime` to add support for the `tokens` macro.
 macro_rules! mock_runtime_with_currencies {
     ($runtime:tt) => {
+        use governance_os_support::{mock_runtime, testing::primitives::Balance};
+
         mock_runtime!($runtime, governance_os_pallet_tokens::AccountData<CurrencyId, Balance>);
 
         impl governance_os_pallet_tokens::RoleBuilder for MockRoles {


### PR DESCRIPTION
- basic code to log organizations and generate their addresses
- add apply_as logic
- create testing mock for organizations pallet
- testing macros self import dependencies
- review code and support modular executors
- organizations updates
- greatly reduce amount of clone calls
- correct iteration pattern
- correct boolean assertion pattern
- test organizations internals
- org_id gets granted roles as well
- drop copy type for role and add organizations to runtime
- add genesis config to node
- fix bylaws benchmarks
