### PR TITLE
organizations decisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,11 +12,11 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
+checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
 dependencies = [
- "gimli 0.22.0",
+ "gimli 0.23.0",
 ]
 
 [[package]]
@@ -95,10 +95,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.14"
+name = "ahash"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
+checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -134,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
+checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
 
 [[package]]
 name = "approx"
@@ -206,36 +212,36 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d373d78ded7d0b3fa8039375718cde0aace493f2e34fb60f51cbf567562ca801"
+checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
  "vec-arena",
 ]
 
 [[package]]
 name = "async-global-executor"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124ac8c265e407641c3362b8f4d39cdb4e243885b71eef087be27199790f5a3a"
+checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
 dependencies = [
  "async-executor",
  "async-io",
  "futures-lite",
  "num_cpus",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
 ]
 
 [[package]]
 name = "async-io"
-version = "1.1.10"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54bc4c1c7292475efb2253227dbcfad8fe1ca4c02bc62c510cc2f3da5c4704e"
+checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
 dependencies = [
  "concurrent-queue",
  "fastrand",
@@ -243,7 +249,7 @@ dependencies = [
  "libc",
  "log",
  "nb-connect",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
  "parking",
  "polling",
  "vec-arena",
@@ -262,15 +268,15 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.6.5"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fa76751505e8df1c7a77762f60486f60c71bbd9b8557f4da6ad47d083732ed"
+checksum = "a7e82538bc65a25dbdff70e4c5439d52f068048ab97cdea0acd73f131594caa1"
 dependencies = [
  "async-global-executor",
  "async-io",
  "async-mutex",
  "blocking",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils 0.8.1",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -280,8 +286,8 @@ dependencies = [
  "log",
  "memchr",
  "num_cpus",
- "once_cell 1.4.1",
- "pin-project-lite",
+ "once_cell 1.5.2",
+ "pin-project-lite 0.1.11",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -299,7 +305,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df097e3f506bec0e1a24f06bb3c962c228f36671de841ff579cb99f371772634"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "rustls",
  "webpki",
  "webpki-roots 0.19.0",
@@ -307,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -353,15 +359,15 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707b586e0e2f247cbde68cdd2c3ce69ea7b7be43e1c5b426e37c9319c4b9838e"
+checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.21.1",
+ "object 0.22.0",
  "rustc-demangle",
 ]
 
@@ -382,6 +388,12 @@ name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bincode"
@@ -477,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.2",
@@ -488,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "blake2s_simd"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9e07352b829279624ceb7c64adb4f585dacdb81d35cafae81139ccd617cf44"
+checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.2",
@@ -554,7 +566,7 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-lite",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
 ]
 
 [[package]]
@@ -562,6 +574,12 @@ name = "bs58"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
@@ -633,9 +651,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.61"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
+checksum = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
 dependencies = [
  "jobserver",
 ]
@@ -752,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "const-random"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dc82c12dc2ee6e1ded861cf7d582b46f66f796d1b6c93fa28b911ead95da02"
+checksum = "486d435a7351580347279f374cb8a3c16937485441db80181357b7c4d70f17ed"
 dependencies = [
  "const-random-macro",
  "proc-macro-hack",
@@ -762,19 +780,21 @@ dependencies = [
 
 [[package]]
 name = "const-random-macro"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc757bbb9544aa296c2ae00c679e81f886b37e28e59097defe0cf524306f6685"
+checksum = "49a84d8ff70e3ec52311109b019c27672b4c1929e4cf7c18bcf0cd9fb5e230be"
 dependencies = [
  "getrandom 0.2.0",
+ "lazy_static",
  "proc-macro-hack",
+ "tiny-keccak",
 ]
 
 [[package]]
 name = "const_fn"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
+checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
 
 [[package]]
 name = "constant_time_eq"
@@ -828,7 +848,7 @@ dependencies = [
  "log",
  "regalloc",
  "serde",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "target-lexicon",
  "thiserror",
 ]
@@ -866,7 +886,7 @@ checksum = "2ef419efb4f94ecc02e5d9fbcc910d2bb7f0040e2de570e63a454f883bc891d6"
 dependencies = [
  "cranelift-codegen",
  "log",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "target-lexicon",
 ]
 
@@ -912,7 +932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -933,8 +953,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-epoch 0.9.1",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -948,21 +968,21 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
- "memoffset",
+ "memoffset 0.5.6",
  "scopeguard 1.1.0",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.1",
  "lazy_static",
- "memoffset",
+ "memoffset 0.6.1",
  "scopeguard 1.1.0",
 ]
 
@@ -990,13 +1010,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg 1.0.1",
  "cfg-if 1.0.0",
- "const_fn",
  "lazy_static",
 ]
 
@@ -1073,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
+checksum = "993a608597367c6377b258c25d7120740f00ed23a2252b729b1932dd7866f908"
 
 [[package]]
 name = "derive_more"
@@ -1183,7 +1202,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "zeroize",
 ]
 
@@ -1254,7 +1273,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
 ]
 
 [[package]]
@@ -1326,7 +1345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8feb87a63249689640ac9c011742c33139204e3c134293d3054022276869133b"
 dependencies = [
  "either",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 2.0.2",
  "log",
  "num-traits",
@@ -1354,11 +1373,11 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da80be589a72651dcda34d8b35bcdc9b7254ad06325611074d9cc0fbb19f60ee"
+checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "crc32fast",
  "libc",
  "libz-sys",
@@ -1378,6 +1397,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98d7f1c606d158d5af4479f2971f259d8dd262f03f6f7b5b37e92eec7b8de396"
 dependencies = [
  "parity-scale-codec",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding 2.1.0",
 ]
 
 [[package]]
@@ -1458,11 +1487,11 @@ dependencies = [
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "log",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
  "parity-scale-codec",
  "paste",
  "serde",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "sp-arithmetic",
  "sp-core",
  "sp-inherents",
@@ -1553,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "fs-swap"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921d332c89b3b61a826de38c61ee5b6e02c56806cade1b0e5d81bd71f57a71bb"
+checksum = "5839fda247e24ca4919c87c71dd5ca658f1f39e4f06829f80e3f15c3bafcfc2c"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1593,9 +1622,9 @@ checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95314d38584ffbfda215621d723e0a3906f032e03ae5551e650058dac83d4797"
+checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1608,9 +1637,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151"
+checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1627,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
+checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
 
 [[package]]
 name = "futures-core-preview"
@@ -1654,7 +1683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdcef58a173af8148b182684c9f2d5250875adbcaff7b5794073894f9d8634a9"
 dependencies = [
  "futures 0.1.30",
- "futures 0.3.7",
+ "futures 0.3.8",
  "lazy_static",
  "log",
  "parking_lot 0.9.0",
@@ -1665,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "futures-executor"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f8e0c9258abaea85e78ebdda17ef9666d390e987f006be6080dfe354b708cb"
+checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1677,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
 
 [[package]]
 name = "futures-lite"
@@ -1692,15 +1721,15 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "waker-fn",
 ]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36fccf3fc58563b4a14d265027c627c3b665d7fed489427e88e7cc929559efe"
+checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1710,17 +1739,17 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3ca3f17d6e8804ae5d3df7a7d35b2b3a6fe89dac84b31872720fc3060a0b11"
+checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
+checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
 dependencies = [
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
 ]
 
 [[package]]
@@ -1737,9 +1766,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
+checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
 dependencies = [
  "futures 0.1.30",
  "futures-channel",
@@ -1749,7 +1778,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.1",
+ "pin-project 1.0.2",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1775,7 +1804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.7",
+ "futures 0.3.8",
  "memchr",
  "pin-project 0.4.27",
 ]
@@ -1884,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "glob"
@@ -2056,6 +2085,7 @@ dependencies = [
  "governance-os-pallet-tokens",
  "governance-os-primitives",
  "governance-os-support",
+ "governance-os-voting",
  "pallet-aura",
  "pallet-grandpa",
  "pallet-randomness-collective-flip",
@@ -2086,6 +2116,17 @@ dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "governance-os-voting"
+version = "0.1.0"
+dependencies = [
+ "governance-os-support",
+ "parity-scale-codec",
+ "serde",
  "sp-runtime",
  "sp-std",
 ]
@@ -2122,7 +2163,7 @@ dependencies = [
  "http 0.2.1",
  "indexmap",
  "slab",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -2178,6 +2219,9 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.6",
+]
 
 [[package]]
 name = "heck"
@@ -2333,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.8"
+version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
+checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
@@ -2347,9 +2391,9 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 0.4.27",
+ "pin-project 1.0.2",
  "socket2",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tower-service",
  "tracing",
  "want 0.3.0",
@@ -2364,11 +2408,11 @@ dependencies = [
  "bytes 0.5.6",
  "ct-logs",
  "futures-util",
- "hyper 0.13.8",
+ "hyper 0.13.9",
  "log",
  "rustls",
  "rustls-native-certs",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-rustls",
  "webpki",
 ]
@@ -2437,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -2459,7 +2503,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa110ec7b8f493f416eed552740d10e7030ad5f63b2308f82c9608ec2df275"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 2.0.2",
 ]
 
@@ -2519,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2680,7 +2724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0315ef2f688e33844400b31f11c263f2b3dc21d8b9355c6891c5f185fae43f9a"
 dependencies = [
  "parity-util-mem",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
 ]
 
 [[package]]
@@ -2709,7 +2753,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "regex",
  "rocksdb",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
 ]
 
 [[package]]
@@ -2760,7 +2804,7 @@ checksum = "571f5a4604c1a40d75651da141dfde29ad15329f537a779528803297d2220274"
 dependencies = [
  "atomic",
  "bytes 0.5.6",
- "futures 0.3.7",
+ "futures 0.3.8",
  "lazy_static",
  "libp2p-core",
  "libp2p-core-derive",
@@ -2787,7 +2831,7 @@ dependencies = [
  "parity-multiaddr",
  "parking_lot 0.10.2",
  "pin-project 0.4.27",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "wasm-timer",
 ]
 
@@ -2798,11 +2842,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f13ba8c7df0768af2eb391696d562c7de88cc3a35122531aaa6a7d77754d25"
 dependencies = [
  "asn1_der",
- "bs58",
+ "bs58 0.3.1",
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "lazy_static",
  "libsecp256k1",
@@ -2818,7 +2862,7 @@ dependencies = [
  "ring",
  "rw-stream-sink",
  "sha2 0.8.2",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "thiserror",
  "unsigned-varint 0.4.0",
  "void",
@@ -2842,7 +2886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74029ae187f35f4b8ddf26b9779a68b340045d708528a103917cdca49a296db5"
 dependencies = [
  "flate2",
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
 ]
 
@@ -2852,7 +2896,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf319822e08dd65c8e060d2354e9f952895bbc433f5706c75ed010c152aee5e"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "log",
 ]
@@ -2865,13 +2909,13 @@ checksum = "d8a9acb43a3e4a4e413e0c4abe0fa49308df7c6335c88534757b647199cb8a51"
 dependencies = [
  "cuckoofilter",
  "fnv",
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "libp2p-swarm",
  "prost",
  "prost-build",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
 ]
 
 [[package]]
@@ -2884,7 +2928,7 @@ dependencies = [
  "byteorder 1.3.4",
  "bytes 0.5.6",
  "fnv",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures_codec",
  "hex_fmt",
  "libp2p-core",
@@ -2895,7 +2939,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sha2 0.8.2",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "unsigned-varint 0.4.0",
  "wasm-timer",
 ]
@@ -2906,13 +2950,13 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56396ee63aa9164eacf40c2c5d2bda8c4133c2f57e1b0425d51d3a4e362583b1"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "libp2p-swarm",
  "log",
  "prost",
  "prost-build",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "wasm-timer",
 ]
 
@@ -2926,7 +2970,7 @@ dependencies = [
  "bytes 0.5.6",
  "either",
  "fnv",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures_codec",
  "libp2p-core",
  "libp2p-swarm",
@@ -2936,7 +2980,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sha2 0.8.2",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "uint",
  "unsigned-varint 0.4.0",
  "void",
@@ -2953,14 +2997,14 @@ dependencies = [
  "data-encoding",
  "dns-parser",
  "either",
- "futures 0.3.7",
+ "futures 0.3.8",
  "lazy_static",
  "libp2p-core",
  "libp2p-swarm",
  "log",
  "net2",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "void",
  "wasm-timer",
 ]
@@ -2973,7 +3017,7 @@ checksum = "8a73a799cc8410b36e40b8f4c4b6babbcb9efd3727111bf517876e4acfa612d3"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures_codec",
  "libp2p-core",
  "log",
@@ -2989,7 +3033,7 @@ checksum = "6ef6c490042f549fb1025f2892dfe6083d97a77558f450c1feebe748ca9eb15a"
 dependencies = [
  "bytes 0.5.6",
  "curve25519-dalek 2.1.0",
- "futures 0.3.7",
+ "futures 0.3.8",
  "lazy_static",
  "libp2p-core",
  "log",
@@ -3009,7 +3053,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad063c21dfcea4518ac9e8bd4119d33a5b26c41e674f602f41f05617a368a5c8"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3025,7 +3069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "903a12e99c72dbebefea258de887982adeacc7025baa1ceb10b7fa9928f54791"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures_codec",
  "libp2p-core",
  "log",
@@ -3042,7 +3086,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b3c2d5d26a9500e959a0e19743897239a6c4be78dadf99b70414301a70c006"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "log",
  "pin-project 0.4.27",
  "rand 0.7.3",
@@ -3058,14 +3102,14 @@ checksum = "9c0c9e8a4cd69d97e9646c54313d007512f411aba8c5226cfcda16df6a6e84a3"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "lru 0.6.0",
+ "lru 0.6.1",
  "minicbor",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "unsigned-varint 0.5.1",
  "wasm-timer",
 ]
@@ -3077,11 +3121,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7193e444210132237b81b755ec7fe53f1c4bd2f53cf719729b94c0c72eb6eaa1"
 dependencies = [
  "either",
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "log",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "void",
  "wasm-timer",
 ]
@@ -3093,7 +3137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44f42ec130d7a37a7e47bf4398026b7ad9185c08ed26972e2720f8b94112796f"
 dependencies = [
  "async-std",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "get_if_addrs",
  "ipnet",
@@ -3109,7 +3153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7acb0a034f70d7db94c300eba3f65c0f6298820105624088a9609c9974d77"
 dependencies = [
  "async-std",
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "log",
 ]
@@ -3120,7 +3164,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34c1faac6f92c21fbe155417957863ea822fba9e9fd5eb24c0912336a100e63f"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "js-sys",
  "libp2p-core",
  "parity-send-wrapper",
@@ -3136,14 +3180,14 @@ checksum = "d650534ebd99f48f6fa292ed5db10d30df2444943afde4407ceeddab8e513fca"
 dependencies = [
  "async-tls",
  "either",
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
  "log",
  "quicksink",
  "rustls",
  "rw-stream-sink",
  "soketto",
- "url 2.1.1",
+ "url 2.2.0",
  "webpki",
  "webpki-roots 0.18.0",
 ]
@@ -3154,9 +3198,9 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "781d9b9f043dcdabc40640807125368596b849fd4d96cdca2dcf052fdf6f33fd"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p-core",
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
  "thiserror",
  "yamux",
 ]
@@ -3246,9 +3290,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
 dependencies = [
  "scopeguard 1.1.0",
 ]
@@ -3286,11 +3330,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111b945ac72ec09eb7bc62a0fbdc3cc6e80555a7245f52a69d3921a75b53b153"
+checksum = "be716eb6878ca2263eb5d00a781aa13264a794f519fe6af4fbb2668b2d5441c0"
 dependencies = [
- "hashbrown 0.8.2",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -3340,9 +3384,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memmap"
@@ -3359,6 +3403,15 @@ name = "memoffset"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg 1.0.1",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -3424,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -3435,7 +3488,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -3461,7 +3514,7 @@ checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
  "mio",
- "miow 0.3.5",
+ "miow 0.3.6",
  "winapi 0.3.9",
 ]
 
@@ -3478,9 +3531,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -3490,9 +3543,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi 0.3.9",
@@ -3513,8 +3566,8 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "digest 0.9.0",
- "sha-1 0.9.1",
- "sha2 0.9.1",
+ "sha-1 0.9.2",
+ "sha2 0.9.2",
  "sha3",
  "unsigned-varint 0.5.1",
 ]
@@ -3527,15 +3580,15 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "multistream-select"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a6aa6e32fbaf16795142335967214b8564a7a4661eb6dc846ef343a6e00ac1"
+checksum = "93faf2e41f9ee62fb01680ed48f3cc26652352327aa2e59869070358f6b7dd75"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.7",
+ "futures 0.3.8",
  "log",
- "pin-project 1.0.1",
- "smallvec 1.4.2",
+ "pin-project 1.0.2",
+ "smallvec 1.5.0",
  "unsigned-varint 0.5.1",
 ]
 
@@ -3577,9 +3630,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "d7cf75f38f16cb05ea017784dc6dbfd354f76c223dba37701734c4f5a9337d02"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -3644,9 +3697,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg 1.0.1",
  "num-traits",
@@ -3666,9 +3719,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg 1.0.1",
  "libm",
@@ -3703,9 +3756,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
+checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "once_cell"
@@ -3718,11 +3771,11 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 dependencies = [
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
 ]
 
 [[package]]
@@ -3893,7 +3946,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -3949,12 +4002,12 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.3"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7ad66970bbab360c97179b60906e2dc4aef1f7fca8ab4e5c5db8c97b16814a"
+checksum = "43244a26dc1ddd3097216bb12eaa6cf8a07b060c72718d9ebd60fd297d6401df"
 dependencies = [
  "arrayref",
- "bs58",
+ "bs58 0.4.0",
  "byteorder 1.3.4",
  "data-encoding",
  "multihash",
@@ -3962,7 +4015,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "unsigned-varint 0.5.1",
- "url 2.1.1",
+ "url 2.2.0",
 ]
 
 [[package]]
@@ -4007,7 +4060,7 @@ dependencies = [
  "libc",
  "log",
  "mio-named-pipes",
- "miow 0.3.5",
+ "miow 0.3.6",
  "rand 0.7.3",
  "tokio 0.1.22",
  "tokio-named-pipes",
@@ -4027,7 +4080,7 @@ dependencies = [
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "primitive-types",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "winapi 0.3.9",
 ]
 
@@ -4063,7 +4116,7 @@ dependencies = [
  "rand 0.7.3",
  "sha-1 0.8.2",
  "slab",
- "url 2.1.1",
+ "url 2.2.0",
 ]
 
 [[package]]
@@ -4105,12 +4158,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
- "lock_api 0.4.1",
+ "lock_api 0.4.2",
  "parking_lot_core 0.8.0",
 ]
 
@@ -4152,7 +4205,7 @@ dependencies = [
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "winapi 0.3.9",
 ]
 
@@ -4167,7 +4220,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "winapi 0.3.9",
 ]
 
@@ -4240,11 +4293,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
 dependencies = [
- "pin-project-internal 1.0.1",
+ "pin-project-internal 1.0.2",
 ]
 
 [[package]]
@@ -4260,9 +4313,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
+checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4274,6 +4327,12 @@ name = "pin-project-lite"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
 
 [[package]]
 name = "pin-utils"
@@ -4317,25 +4376,25 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5884790f1ce3553ad55fec37b5aaac5882e0e845a2612df744d6c85c9bf046c"
+checksum = "b3fd900a291ceb8b99799cc8cd3d1d3403a51721e015bc533528b2ceafcc443c"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "universal-hash",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "primitive-types"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55c21c64d0eaa4d7ed885d959ef2d62d9e488c27c0e02d9aa5ce6c877b7d5f8"
+checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -4378,9 +4437,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
@@ -4406,7 +4465,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "fnv",
  "lazy_static",
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
  "regex",
  "thiserror",
 ]
@@ -4487,7 +4546,7 @@ checksum = "77de3c815e5a160b1539c6592796801df2043ae35e123b46d73380cfa57af858"
 dependencies = [
  "futures-core",
  "futures-sink",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
 ]
 
 [[package]]
@@ -4735,7 +4794,7 @@ checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.1",
  "lazy_static",
  "num_cpus",
 ]
@@ -4768,18 +4827,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745c1787167ddae5569661d5ffb8b25ae5fedbf46717eaa92d652221cec72623"
+checksum = "e17626b2f4bcf35b84bf379072a66e28cfe5c3c6ae58b38e4914bb8891dabece"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d21b475ab879ef0e315ad99067fa25778c3b0377f57f1b00207448dac1a3144"
+checksum = "0c523ccaed8ac4b0288948849a350b37d3035827413c458b6a40ddb614bb4f72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4794,14 +4853,14 @@ checksum = "b9ba8aaf5fe7cf307c6dbdaeed85478961d29e25e3bee5169e11b92fa9f027a8"
 dependencies = [
  "log",
  "rustc-hash",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8963b85b8ce3074fecffde43b4b0dded83ce2f367dc8d363afc56679f3ee820b"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4821,9 +4880,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "region"
@@ -4854,13 +4913,13 @@ checksum = "e005d658ad26eacc2b6c506dfde519f4e277e328d0eb3379ca61647d70a8f531"
 
 [[package]]
 name = "ring"
-version = "0.16.15"
+version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
+checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
 dependencies = [
  "cc",
  "libc",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
  "spin",
  "untrusted",
  "web-sys",
@@ -4889,14 +4948,14 @@ dependencies = [
 
 [[package]]
 name = "rust-argon2"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -4957,7 +5016,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "pin-project 0.4.27",
  "static_assertions",
 ]
@@ -4992,7 +5051,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527f6822cf592ac2b4a6ca7d04601c48d6728b8c03d9a9cc0488e4b535c69c6d"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5071,7 +5130,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "fdlimit",
- "futures 0.3.7",
+ "futures 0.3.8",
  "hex",
  "lazy_static",
  "libp2p",
@@ -5103,7 +5162,7 @@ dependencies = [
  "structopt",
  "substrate-prometheus-endpoint",
  "time",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -5117,7 +5176,7 @@ checksum = "9fafb2b2861e847657c4656d2ae2249c9f3f6a76fb92a22f750325b77e1fb4c8"
 dependencies = [
  "derive_more",
  "fnv",
- "futures 0.3.7",
+ "futures 0.3.8",
  "hash-db",
  "hex-literal",
  "kvdb",
@@ -5196,7 +5255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b4fbf217f3942ae545ad70cd5b5d567b4519b9acb07b35e0de5cce7e7ef195"
 dependencies = [
  "derive_more",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5227,7 +5286,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69a334a099d5cac9054ea1ef1db4be8ed5518270027798f96d2a68c5bf69af8e"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5336,7 +5395,7 @@ dependencies = [
  "derive_more",
  "finality-grandpa",
  "fork-tree",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5372,7 +5431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b81dbdbba0420bb4c0bf2a79bcbb78de5bd1349aad8467b3115f82be579b2972"
 dependencies = [
  "ansi_term 0.12.1",
- "futures 0.3.7",
+ "futures 0.3.8",
  "log",
  "parity-util-mem",
  "sc-client-api",
@@ -5430,14 +5489,14 @@ dependencies = [
  "async-std",
  "async-trait",
  "bitflags",
- "bs58",
+ "bs58 0.3.1",
  "bytes 0.5.6",
  "derive_more",
  "either",
  "erased-serde",
  "fnv",
  "fork-tree",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "futures_codec",
  "hex",
@@ -5482,7 +5541,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ddb2a1cb6cd53b46e76f61c662d1561da4a7dc16a375c37849fd1f429b6803"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -5500,9 +5559,9 @@ checksum = "79495bd858351489fcebeb4e47821e15329ad5606f0d7983836e069005c3d9dd"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
- "hyper 0.13.8",
+ "hyper 0.13.9",
  "hyper-rustls",
  "log",
  "num_cpus",
@@ -5526,7 +5585,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfaa3d62db8ad549e6d21b6e353e00e2e7338c8623c01c79e8f36b035266a4b"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "libp2p",
  "log",
  "serde_json",
@@ -5550,7 +5609,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc3793d8ff10dbeb0b683151a1ea33570dc994195cc29451e0b72ce35179adc"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
@@ -5584,7 +5643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfb4b79b9b6b410c745a00eb4ead11b2ef0819e6eac970a5ec6415abf82777be"
 dependencies = [
  "derive_more",
- "futures 0.3.7",
+ "futures 0.3.8",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -5631,7 +5690,7 @@ dependencies = [
  "directories",
  "exit-future",
  "futures 0.1.30",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "hash-db",
  "jsonrpc-core",
@@ -5705,7 +5764,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5883219d0ccec3e4d50079ba63f8accc71659b93537cff66de326a382b138c4b"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -5748,7 +5807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31fed765b519362f7ae824a2d3a2e6ee9912ac972e8ff61838d4ff0831cb3077"
 dependencies = [
  "derive_more",
- "futures 0.3.7",
+ "futures 0.3.8",
  "linked-hash-map",
  "log",
  "parity-util-mem",
@@ -5770,7 +5829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248d4bcde22c936b462e4aa6c32e0f49a96942b123a1a46bc60cd02fbf907002"
 dependencies = [
  "derive_more",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-diagnose",
  "intervalier",
  "log",
@@ -5958,12 +6017,12 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
+checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -5983,12 +6042,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -6024,11 +6083,10 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
+checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
- "arc-swap",
  "libc",
 ]
 
@@ -6046,9 +6104,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "slog"
-version = "2.5.2"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 dependencies = [
  "erased-serde",
 ]
@@ -6099,9 +6157,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 
 [[package]]
 name = "snow"
@@ -6116,18 +6174,18 @@ dependencies = [
  "rand_core 0.5.1",
  "ring",
  "rustc_version",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "subtle 2.3.0",
  "x25519-dalek 1.1.0",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -6142,11 +6200,11 @@ dependencies = [
  "base64 0.12.3",
  "bytes 0.5.6",
  "flate2",
- "futures 0.3.7",
+ "futures 0.3.8",
  "httparse",
  "log",
  "rand 0.7.3",
- "sha-1 0.9.1",
+ "sha-1 0.9.2",
 ]
 
 [[package]]
@@ -6278,7 +6336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b460103293bbf2f4193e43c4f031fdc099c5e27c782369bbb4dacc7765e84057"
 dependencies = [
  "derive_more",
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -6335,7 +6393,7 @@ dependencies = [
  "derive_more",
  "dyn-clonable",
  "ed25519-dalek",
- "futures 0.3.7",
+ "futures 0.3.8",
  "hash-db",
  "hash256-std-hasher",
  "hex",
@@ -6448,7 +6506,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e1dee9244eb6cba1bef9b3a4ec288185e1380e455f1fd348b60252592c1cf0"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "hash-db",
  "libsecp256k1",
  "log",
@@ -6609,7 +6667,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
@@ -6675,7 +6733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83b34ee48341c17c6e2f1e55f6076918f46b0c4505a99ad69ab1edda8b45bbd8"
 dependencies = [
  "derive_more",
- "futures 0.3.7",
+ "futures 0.3.8",
  "log",
  "parity-scale-codec",
  "serde",
@@ -6705,7 +6763,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84310a02e2ac89b5e288d7af980414fd88753e3caba92aab1983cd2819991150"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "futures-core",
  "futures-timer 3.0.2",
  "lazy_static",
@@ -6791,9 +6849,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -6802,9 +6860,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -6863,7 +6921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44e6202803178f25f71a3218a69341289d38c1369cc63e78dfe51577599163f7"
 dependencies = [
  "frame-system-rpc-runtime-api",
- "futures 0.3.7",
+ "futures 0.3.8",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -6889,10 +6947,10 @@ dependencies = [
  "async-std",
  "derive_more",
  "futures-util",
- "hyper 0.13.8",
+ "hyper 0.13.9",
  "log",
  "prometheus",
- "tokio 0.2.22",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -6915,9 +6973,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "8833e20724c24de12bbaba5ad230ea61c3eafb05b881c7c9d3cfe8638b187e68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6964,9 +7022,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
@@ -6982,18 +7040,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7037,7 +7095,7 @@ checksum = "b0165e045cc2ae1660270ca65e1676dbaab60feb0f91b10f7d0665e9b47e31f2"
 dependencies = [
  "failure",
  "hmac",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
  "pbkdf2",
  "rand 0.7.3",
  "rustc-hash",
@@ -7056,9 +7114,18 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
@@ -7086,9 +7153,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -7100,7 +7167,7 @@ dependencies = [
  "mio",
  "mio-uds",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
  "winapi 0.3.9",
@@ -7221,7 +7288,7 @@ checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "webpki",
 ]
 
@@ -7341,8 +7408,8 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
- "tokio 0.2.22",
+ "pin-project-lite 0.1.11",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -7362,13 +7429,13 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.0",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -7426,9 +7493,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2810660b9d5b18895d140caba6401765749a6a162e5d0736cfc44ea50db9d79d"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -7438,7 +7505,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -7456,7 +7523,7 @@ dependencies = [
  "hashbrown 0.8.2",
  "log",
  "rustc-hex",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
 ]
 
 [[package]]
@@ -7523,18 +7590,18 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"
@@ -7599,10 +7666,11 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna 0.2.0",
  "matches",
  "percent-encoding 2.1.0",
@@ -7679,19 +7747,19 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -7704,11 +7772,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -7716,9 +7784,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7726,9 +7794,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7739,9 +7807,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
 name = "wasm-timer"
@@ -7749,9 +7817,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "js-sys",
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
  "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -7807,7 +7875,7 @@ dependencies = [
  "log",
  "region",
  "rustc-demangle",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "target-lexicon",
  "wasmparser 0.59.0",
  "wasmtime-environ",
@@ -7940,7 +8008,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "memoffset",
+ "memoffset 0.5.6",
  "more-asserts",
  "region",
  "thiserror",
@@ -7950,27 +8018,27 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "26.0.1"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f174eed73e885ede6c8fcc3fbea8c3757afa521840676496cde56bb742ddab"
+checksum = "c2c3ef5f6a72dffa44c24d5811123f704e18a1dbc83637d347b1852b41d3835c"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b2dccbce4d0e14875091846e110a2369267b18ddd0d6423479b88dad914d71"
+checksum = "835cf59c907f67e2bbc20f50157e08f35006fe2a8444d8ec9f5683e22f937045"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7978,9 +8046,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
@@ -8103,10 +8171,10 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aeb8c4043cac71c3c299dff107171c220d179492350ea198e109a414981b83c"
 dependencies = [
- "futures 0.3.7",
+ "futures 0.3.8",
  "log",
  "nohash-hasher",
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
  "rand 0.7.3",
  "static_assertions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,6 +2027,7 @@ dependencies = [
  "governance-os-pallet-bylaws",
  "governance-os-pallet-tokens",
  "governance-os-support",
+ "governance-os-voting",
  "parity-scale-codec",
  "serde",
  "sp-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,6 +1996,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "governance-os-pallet-bylaws",
+ "governance-os-pallet-tokens",
  "governance-os-support",
  "parity-scale-codec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,9 +2124,15 @@ dependencies = [
 name = "governance-os-voting"
 version = "0.1.0"
 dependencies = [
+ "frame-support",
+ "frame-system",
+ "governance-os-pallet-bylaws",
+ "governance-os-pallet-tokens",
  "governance-os-support",
  "parity-scale-codec",
  "serde",
+ "sp-core",
+ "sp-io",
  "sp-runtime",
  "sp-std",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ members = [
     'primitives',
     'runtime',
     'support',
+    'voting',
 ]

--- a/pallets/bylaws/src/benchmarking.rs
+++ b/pallets/bylaws/src/benchmarking.rs
@@ -17,7 +17,7 @@
 use crate::*;
 use frame_benchmarking::{account, benchmarks, whitelisted_caller};
 use frame_system::RawOrigin;
-use governance_os_support::{acl::RoleManager, benchmarking::SEED};
+use governance_os_support::{benchmarking::SEED, traits::RoleManager};
 use sp_runtime::traits::StaticLookup;
 use sp_std::prelude::*;
 

--- a/pallets/bylaws/src/lib.rs
+++ b/pallets/bylaws/src/lib.rs
@@ -24,7 +24,7 @@
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, traits::Get, weights::Weight, Parameter,
 };
-use governance_os_support::acl::RoleManager;
+use governance_os_support::traits::RoleManager;
 use sp_runtime::{
     traits::{MaybeSerializeDeserialize, Member, StaticLookup},
     DispatchResult,

--- a/pallets/bylaws/src/lib.rs
+++ b/pallets/bylaws/src/lib.rs
@@ -22,10 +22,13 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::{
-    decl_error, decl_event, decl_module, decl_storage, traits::Get, weights::Weight,
+    decl_error, decl_event, decl_module, decl_storage, traits::Get, weights::Weight, Parameter,
 };
-use governance_os_support::acl::{Role, RoleManager};
-use sp_runtime::{traits::StaticLookup, DispatchResult};
+use governance_os_support::acl::RoleManager;
+use sp_runtime::{
+    traits::{MaybeSerializeDeserialize, Member, StaticLookup},
+    DispatchResult,
+};
 use sp_std::prelude::Vec;
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -55,7 +58,7 @@ pub trait Trait: frame_system::Trait {
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 
     /// Roles defines UNIX like roles that users must be granted before triggering certain calls.
-    type Role: Role + Default;
+    type Role: Parameter + Member + MaybeSerializeDeserialize + Ord + Default;
 
     /// The weights for this pallet.
     type WeightInfo: WeightInfo;

--- a/pallets/bylaws/src/tests/dispatchable.rs
+++ b/pallets/bylaws/src/tests/dispatchable.rs
@@ -18,8 +18,8 @@ use super::mock::*;
 use frame_support::assert_ok;
 use frame_system::RawOrigin;
 use governance_os_support::{
-    acl::RoleManager,
     testing::{ALICE, ROOT},
+    traits::RoleManager,
 };
 
 #[test]

--- a/pallets/bylaws/src/tests/mod.rs
+++ b/pallets/bylaws/src/tests/mod.rs
@@ -16,4 +16,4 @@
 
 mod dispatchable;
 mod genesis;
-mod mock;
+pub mod mock;

--- a/pallets/bylaws/src/tests/mod.rs
+++ b/pallets/bylaws/src/tests/mod.rs
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-pub mod dispatchable;
-pub mod genesis;
-pub mod mock;
+mod dispatchable;
+mod genesis;
+mod mock;

--- a/pallets/bylaws/src/tests/role_manager.rs
+++ b/pallets/bylaws/src/tests/role_manager.rs
@@ -16,8 +16,8 @@
 
 use super::mock::*;
 use governance_os_support::{
-    acl::RoleManager,
     testing::{ALICE, BOB},
+    traits::RoleManager,
 };
 
 #[test]

--- a/pallets/compat/src/lib.rs
+++ b/pallets/compat/src/lib.rs
@@ -30,7 +30,7 @@ use frame_support::{
     Parameter,
 };
 use governance_os_pallet_bylaws::RoleBuilder;
-use governance_os_support::acl::RoleManager;
+use governance_os_support::traits::RoleManager;
 use sp_runtime::{traits::StaticLookup, DispatchResult};
 use sp_std::boxed::Box;
 

--- a/pallets/compat/src/tests/dispatchable.rs
+++ b/pallets/compat/src/tests/dispatchable.rs
@@ -17,7 +17,7 @@
 use super::mock::*;
 use frame_support::{assert_noop, assert_ok};
 use governance_os_support::{
-    acl::AclError,
+    errors::AclError,
     testing::{ALICE, BOB},
 };
 

--- a/pallets/compat/src/tests/mod.rs
+++ b/pallets/compat/src/tests/mod.rs
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-pub mod dispatchable;
-pub mod mock;
+mod dispatchable;
+mod mock;

--- a/pallets/organizations/Cargo.toml
+++ b/pallets/organizations/Cargo.toml
@@ -17,6 +17,7 @@ version = '1.3.4'
 [dependencies]
 frame-support = { default-features = false, version = '2.0.0' }
 frame-system = { default-features = false, version = '2.0.0' }
+governance-os-pallet-tokens = { default-features = false, path = '../tokens' }
 governance-os-support = { default-features = false, path = '../../support' }
 serde = { version = "1.0.116", optional = true }
 sp-runtime = { default-features = false, version = '2.0.0' }
@@ -34,6 +35,7 @@ std = [
     'codec/std',
     'frame-support/std',
     'frame-system/std',
+    'governance-os-pallet-tokens/std',
     'governance-os-support/std',
     'serde',
     'sp-runtime/std',

--- a/pallets/organizations/Cargo.toml
+++ b/pallets/organizations/Cargo.toml
@@ -25,6 +25,7 @@ sp-std = { default-features = false, version = "2.0.0" }
 
 [dev-dependencies]
 governance-os-pallet-bylaws = { path = '../bylaws' }
+governance-os-voting = { path = '../../voting' }
 serde = '1.0.116'
 sp-core = '2.0.0'
 sp-io = '2.0.0'

--- a/pallets/organizations/Cargo.toml
+++ b/pallets/organizations/Cargo.toml
@@ -42,3 +42,4 @@ std = [
     'sp-runtime/std',
     'sp-std/std',
 ]
+runtime-benchmarks = []

--- a/pallets/organizations/src/details.rs
+++ b/pallets/organizations/src/details.rs
@@ -23,15 +23,28 @@ use sp_std::prelude::Vec;
 /// This structure is used to encode metadata about an organization.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct OrganizationDetails<AccountId> {
+pub struct OrganizationDetails<AccountId, VotingSystem> {
     /// A set of accounts that have access to the `apply_as` function
     /// of an organization.
     pub executors: Vec<AccountId>,
+
+    /// Which voting system is in place. `executors` do not need to go
+    /// through it due to their higher privilege permission.
+    pub voting: VotingSystem,
 }
 
-impl<AccountId: Ord> OrganizationDetails<AccountId> {
+impl<AccountId: Ord, VotingSystem> OrganizationDetails<AccountId, VotingSystem> {
     /// Sort all the vectors inside the strutcture.
     pub fn sort(&mut self) {
         self.executors.sort();
     }
+}
+
+/// Represent a proposal as stored by the pallet.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct Proposal<AccountId, Call, Metadata> {
+    pub creator: AccountId,
+    pub call: Call,
+    pub metadata: Metadata,
 }

--- a/pallets/organizations/src/details.rs
+++ b/pallets/organizations/src/details.rs
@@ -41,7 +41,7 @@ impl<AccountId: Ord, VotingSystem> OrganizationDetails<AccountId, VotingSystem> 
 }
 
 /// Represent a proposal as stored by the pallet.
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct Proposal<Call, Metadata, OrganizationId, VotingSystem> {
     pub org: OrganizationId,

--- a/pallets/organizations/src/details.rs
+++ b/pallets/organizations/src/details.rs
@@ -27,15 +27,11 @@ pub struct OrganizationDetails<AccountId> {
     /// A set of accounts that have access to the `apply_as` function
     /// of an organization.
     pub executors: Vec<AccountId>,
-
-    /// A set of accounts that can change an organization's parameters.
-    pub managers: Vec<AccountId>,
 }
 
 impl<AccountId: Ord> OrganizationDetails<AccountId> {
     /// Sort all the vectors inside the strutcture.
     pub fn sort(&mut self) {
         self.executors.sort();
-        self.managers.sort();
     }
 }

--- a/pallets/organizations/src/details.rs
+++ b/pallets/organizations/src/details.rs
@@ -43,8 +43,9 @@ impl<AccountId: Ord, VotingSystem> OrganizationDetails<AccountId, VotingSystem> 
 /// Represent a proposal as stored by the pallet.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct Proposal<AccountId, Call, Metadata> {
-    pub creator: AccountId,
+pub struct Proposal<Call, Metadata, OrganizationId, VotingSystem> {
+    pub org: OrganizationId,
     pub call: Call,
     pub metadata: Metadata,
+    pub voting: VotingSystem,
 }

--- a/pallets/organizations/src/lib.rs
+++ b/pallets/organizations/src/lib.rs
@@ -30,12 +30,10 @@ use frame_support::{
 };
 use frame_system::ensure_signed;
 use governance_os_support::{
-    acl::RoleManager,
-    voting::{VotingHooks, VotingSystem},
-    Currencies, ReservableCurrencies,
+    acl::RoleManager, voting::VotingHooks, Currencies, ReservableCurrencies,
 };
 use sp_runtime::{
-    traits::{AccountIdConversion, Hash, StaticLookup},
+    traits::{AccountIdConversion, Hash, MaybeSerializeDeserialize, Member, StaticLookup},
     DispatchError, DispatchResult, ModuleId,
 };
 use sp_std::{boxed::Box, prelude::Vec};
@@ -82,7 +80,7 @@ pub trait Trait: frame_system::Trait {
     /// The different kinds of voting system present inside the runtime.
     /// **NOTE**: The `Default` voting system will be the one used during benchmarks,
     /// thus you should probably set the most expensive one as the default.
-    type VotingSystem: VotingSystem + Default;
+    type VotingSystem: Parameter + Member + Copy + MaybeSerializeDeserialize + Default;
 
     /// Some arbitrary data that can be added to proposals
     type ProposalMetadata: Parameter + Default;

--- a/pallets/organizations/src/lib.rs
+++ b/pallets/organizations/src/lib.rs
@@ -80,7 +80,7 @@ pub trait Trait: frame_system::Trait {
     /// The different kinds of voting system present inside the runtime.
     /// **NOTE**: The `Default` voting system will be the one used during benchmarks,
     /// thus you should probably set the most expensive one as the default.
-    type VotingSystem: Parameter + Member + Copy + MaybeSerializeDeserialize + Default;
+    type VotingSystem: Parameter + Member + MaybeSerializeDeserialize + Default;
 
     /// Some arbitrary data that can be added to proposals
     type ProposalMetadata: Parameter + Default;

--- a/pallets/organizations/src/lib.rs
+++ b/pallets/organizations/src/lib.rs
@@ -100,6 +100,12 @@ pub trait Trait: frame_system::Trait {
 type OrganizationDetailsOf<T> =
     OrganizationDetails<<T as frame_system::Trait>::AccountId, <T as Trait>::VotingSystem>;
 type ProposalIdOf<T> = <T as frame_system::Trait>::Hash;
+type ProposalOf<T> = Proposal<
+    Vec<u8>,
+    <T as Trait>::ProposalMetadata,
+    <T as frame_system::Trait>::AccountId,
+    <T as Trait>::VotingSystem,
+>;
 type RoleBuilderOf<T> = <T as Trait>::RoleBuilder;
 type RoleManagerOf<T> = <T as Trait>::RoleManager;
 
@@ -109,7 +115,7 @@ decl_storage! {
     trait Store for Module<T: Trait> as Organizations {
         pub Counter get(fn counter): u32 = 0;
         pub Parameters get(fn parameters): map hasher(blake2_128_concat) T::AccountId => OrganizationDetailsOf<T>;
-        pub Proposals get(fn proposals): map hasher(blake2_128_concat) ProposalIdOf<T> => Proposal<Vec<u8>, T::ProposalMetadata, T::AccountId, T::VotingSystem>;
+        pub Proposals get(fn proposals): map hasher(blake2_128_concat) ProposalIdOf<T> => ProposalOf<T>;
     }
     add_extra_genesis {
         config(organizations): Vec<OrganizationDetailsOf<T>>;

--- a/pallets/organizations/src/lib.rs
+++ b/pallets/organizations/src/lib.rs
@@ -30,7 +30,8 @@ use frame_support::{
 };
 use frame_system::ensure_signed;
 use governance_os_support::{
-    acl::RoleManager, ensure_not_err, voting::VotingHooks, Currencies, ReservableCurrencies,
+    ensure_not_err,
+    traits::{Currencies, ReservableCurrencies, RoleManager, VotingHooks},
 };
 use sp_runtime::{
     traits::{AccountIdConversion, Hash, MaybeSerializeDeserialize, Member, StaticLookup},

--- a/pallets/organizations/src/lib.rs
+++ b/pallets/organizations/src/lib.rs
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-//! This pallet bundles together the `bylaws` and `tokens` ones to create and
-//! manage decentralized autonomous organizations.
-//! Note that we give an account id to every organization created, this opens up
-//! the possibility to send some funds to an organization and have it spend the funds
-//! itself with no additional logic.
+//! This pallets creates and manages a set of organizations. An organization is linked
+//! to a set of executors that can call its `apply_as` function to execute calls as if
+//! it came from it.
+//! For instance, a voting contract could be deployed and registered as an executor.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/pallets/organizations/src/tests/details.rs
+++ b/pallets/organizations/src/tests/details.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use super::mock::MockVotingSystem;
 use crate::OrganizationDetails;
 use governance_os_support::testing::{ALICE, BOB};
 
@@ -21,6 +22,7 @@ use governance_os_support::testing::{ALICE, BOB};
 fn sort() {
     let mut details = OrganizationDetails {
         executors: vec![BOB, ALICE],
+        voting: MockVotingSystem::None,
     };
     details.sort();
     assert_eq!(details.executors, vec![ALICE, BOB]);

--- a/pallets/organizations/src/tests/details.rs
+++ b/pallets/organizations/src/tests/details.rs
@@ -14,15 +14,19 @@
  * limitations under the License.
  */
 
-use super::mock::MockVotingSystem;
+use super::mock::Tokens;
 use crate::OrganizationDetails;
-use governance_os_support::testing::{ALICE, BOB};
+use governance_os_support::testing::{
+    primitives::{AccountId, Balance, BlockNumber, CurrencyId},
+    ALICE, BOB,
+};
+use governance_os_voting::VotingSystems;
 
 #[test]
 fn sort() {
     let mut details = OrganizationDetails {
         executors: vec![BOB, ALICE],
-        voting: MockVotingSystem::None,
+        voting: VotingSystems::<Balance, CurrencyId, BlockNumber, Tokens, AccountId>::None,
     };
     details.sort();
     assert_eq!(details.executors, vec![ALICE, BOB]);

--- a/pallets/organizations/src/tests/details.rs
+++ b/pallets/organizations/src/tests/details.rs
@@ -21,9 +21,7 @@ use governance_os_support::testing::{ALICE, BOB};
 fn sort() {
     let mut details = OrganizationDetails {
         executors: vec![BOB, ALICE],
-        managers: vec![BOB, ALICE],
     };
     details.sort();
     assert_eq!(details.executors, vec![ALICE, BOB]);
-    assert_eq!(details.managers, vec![ALICE, BOB]);
 }

--- a/pallets/organizations/src/tests/dispatchable.rs
+++ b/pallets/organizations/src/tests/dispatchable.rs
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-use super::mock::{Bylaws, Call, ExtBuilder, MockRoles, Organizations};
-use crate::{OrganizationDetails, RoleBuilder};
+use super::mock::{Bylaws, Call, ExtBuilder, MockRoles, Organizations, Test};
+use crate::{Error, OrganizationDetails, RoleBuilder};
 use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
 use governance_os_support::{
     acl::{AclError, RoleManager},
-    testing::{ALICE, BOB, CHARLIE, EVE},
+    testing::{ALICE, BOB, CHARLIE},
 };
 
 #[test]
@@ -34,7 +34,6 @@ fn create_increments_counter_and_save_details_and_configure_roles() {
                 OrganizationDetails {
                     // We intentionally make it unsorted for the test
                     executors: vec![CHARLIE, BOB],
-                    managers: vec![EVE, ALICE],
                 }
             ));
             assert_eq!(Organizations::counter(), 1);
@@ -43,7 +42,6 @@ fn create_increments_counter_and_save_details_and_configure_roles() {
 
             let params = Organizations::parameters(org_id);
             assert_eq!(params.executors.as_slice(), [BOB, CHARLIE]);
-            assert_eq!(params.managers.as_slice(), [ALICE, EVE]);
 
             assert!(Bylaws::has_role(
                 &CHARLIE,
@@ -52,24 +50,6 @@ fn create_increments_counter_and_save_details_and_configure_roles() {
             assert!(Bylaws::has_role(
                 &BOB,
                 MockRoles::apply_as_organization(&org_id)
-            ));
-            assert!(Bylaws::has_role(
-                &ALICE,
-                MockRoles::manage_organization(&org_id)
-            ));
-            assert!(Bylaws::has_role(
-                &EVE,
-                MockRoles::manage_organization(&org_id)
-            ));
-
-            // Org ID is granted roles as well
-            assert!(Bylaws::has_role(
-                &org_id,
-                MockRoles::apply_as_organization(&org_id)
-            ));
-            assert!(Bylaws::has_role(
-                &org_id,
-                MockRoles::manage_organization(&org_id)
             ));
         })
 }
@@ -84,7 +64,6 @@ fn apply_as() {
                 RawOrigin::Signed(ALICE).into(),
                 OrganizationDetails {
                     executors: vec![ALICE],
-                    managers: vec![],
                 }
             ));
             assert_ok!(Organizations::apply_as(
@@ -105,31 +84,23 @@ fn mutate_save_details_and_update_roles() {
                 RawOrigin::Signed(ALICE).into(),
                 OrganizationDetails {
                     executors: vec![ALICE, BOB],
-                    managers: vec![ALICE, BOB],
                 }
             ));
             let org_id = Organizations::org_id_for(0);
             assert_ok!(Organizations::mutate(
-                RawOrigin::Signed(ALICE).into(),
-                org_id,
+                RawOrigin::Signed(org_id).into(),
                 OrganizationDetails {
                     executors: vec![ALICE, CHARLIE],
-                    managers: vec![ALICE, CHARLIE]
                 },
             ));
 
             let params = Organizations::parameters(org_id);
             assert_eq!(params.executors.as_slice(), [ALICE, CHARLIE]);
-            assert_eq!(params.managers.as_slice(), [ALICE, CHARLIE]);
 
             // BOB lost permissions
             assert!(!Bylaws::has_role(
                 &BOB,
                 MockRoles::apply_as_organization(&org_id)
-            ));
-            assert!(!Bylaws::has_role(
-                &BOB,
-                MockRoles::manage_organization(&org_id)
             ));
 
             // ALICE kept them
@@ -137,19 +108,11 @@ fn mutate_save_details_and_update_roles() {
                 &ALICE,
                 MockRoles::apply_as_organization(&org_id)
             ));
-            assert!(Bylaws::has_role(
-                &ALICE,
-                MockRoles::manage_organization(&org_id)
-            ));
 
             // CHARLIE won them
             assert!(Bylaws::has_role(
                 &CHARLIE,
                 MockRoles::apply_as_organization(&org_id)
-            ));
-            assert!(Bylaws::has_role(
-                &CHARLIE,
-                MockRoles::manage_organization(&org_id)
             ));
         })
 }
@@ -185,7 +148,7 @@ fn apply_as_fail_if_not_correct_role() {
 }
 
 #[test]
-fn mutate_fail_if_not_correct_role() {
+fn mutate_fail_if_not_the_org_itself() {
     ExtBuilder::default()
         .with_default_orgs(1)
         .build()
@@ -193,10 +156,9 @@ fn mutate_fail_if_not_correct_role() {
             assert_noop!(
                 Organizations::mutate(
                     RawOrigin::Signed(ALICE).into(),
-                    Organizations::org_id_for(0),
                     OrganizationDetails::default()
                 ),
-                AclError::MissingRole
+                Error::<Test>::NotAnOrganization,
             );
         })
 }

--- a/pallets/organizations/src/tests/dispatchable.rs
+++ b/pallets/organizations/src/tests/dispatchable.rs
@@ -19,12 +19,12 @@ use crate::{Error, OrganizationDetails, Proposal, Proposals, RoleBuilder};
 use frame_support::{assert_noop, assert_ok, StorageMap};
 use frame_system::RawOrigin;
 use governance_os_support::{
-    acl::{AclError, RoleManager},
+    errors::AclError,
     testing::{
         primitives::{AccountId, Balance, BlockNumber, CurrencyId},
         ALICE, BOB, CHARLIE, TEST_TOKEN_ID,
     },
-    ReservableCurrencies,
+    traits::{ReservableCurrencies, RoleManager},
 };
 use governance_os_voting::{
     CoinBasedVotingParameters, ProposalMetadata, VotingErrors, VotingSystems,

--- a/pallets/organizations/src/tests/mock.rs
+++ b/pallets/organizations/src/tests/mock.rs
@@ -19,7 +19,7 @@ use governance_os_pallet_tokens::CurrencyDetails;
 use governance_os_support::{
     mock_runtime_with_currencies,
     testing::{ALICE, TEST_TOKEN_ID, TEST_TOKEN_OWNER},
-    voting::{VotingHooks, VotingSystem},
+    voting::VotingHooks,
     Currencies, ReservableCurrencies,
 };
 use sp_runtime::DispatchResult;
@@ -32,7 +32,6 @@ pub enum MockVotingSystem {
     SimpleReserveWithCreationFee(CurrencyId, Balance),
 }
 impl_enum_default!(MockVotingSystem, None);
-impl VotingSystem for MockVotingSystem {}
 
 #[derive(Default, Eq, PartialEq, RuntimeDebug, Encode, Decode, Clone, Serialize, Deserialize)]
 pub struct VotingSystemMetadata {

--- a/pallets/organizations/src/tests/mock.rs
+++ b/pallets/organizations/src/tests/mock.rs
@@ -51,10 +51,12 @@ impl VotingHooks for MockVotingSystem {
     type VotingSystem = Self;
     type Currencies = Tokens;
     type Data = VotingSystemMetadata;
+    type BlockNumber = BlockNumber;
 
-    fn on_creating_proposal(
+    fn on_create_proposal(
         voting_system: Self::VotingSystem,
         creator: &Self::AccountId,
+        _current_block: Self::BlockNumber,
     ) -> (DispatchResult, Self::Data) {
         match voting_system {
             Self::SimpleReserveWithCreationFee(currency_id, creation_fee) => (
@@ -109,13 +111,21 @@ impl VotingHooks for MockVotingSystem {
         }
     }
 
-    fn on_close_proposal(voting_system: Self::VotingSystem, data: Self::Data, _executed: bool) {
+    fn on_close_proposal(
+        voting_system: Self::VotingSystem,
+        data: Self::Data,
+        _executed: bool,
+    ) -> DispatchResult {
         // In our case the logic than when vetoing the proposal. Let's just call this and
         // ignore the dispatch result.
-        drop(Self::on_veto_proposal(voting_system, data));
+        Self::on_veto_proposal(voting_system, data)
     }
 
-    fn can_close(_voting_system: Self::VotingSystem, data: Self::Data) -> bool {
+    fn can_close(
+        _voting_system: Self::VotingSystem,
+        data: Self::Data,
+        _block: Self::BlockNumber,
+    ) -> bool {
         data.in_favor + data.in_opposition > 0
     }
 

--- a/pallets/organizations/src/tests/mock.rs
+++ b/pallets/organizations/src/tests/mock.rs
@@ -42,6 +42,10 @@ pub struct VotingSystemMetadata {
     pub in_opposition: Balance,
 }
 
+// /!\ WARNING /!\:
+// PLEASE DO NOT USE THIS IN PRODUCTION! THIS CODE IS RESERVED FOR MOCKS AND TESTS
+// AND WOULD NOT SURVIVE CONTACT WITH USERS AND MALICIOUS ATCORS IN A PRODUCTION
+// VOTING SYSTEM. ALSO IT IS SUPER UNOPTIMIZED.
 impl VotingHooks for MockVotingSystem {
     type AccountId = AccountId;
     type OrganizationId = AccountId;
@@ -104,6 +108,20 @@ impl VotingHooks for MockVotingSystem {
             }
             _ => (Err("none voting system".into()), data),
         }
+    }
+
+    fn on_close_proposal(voting_system: Self::VotingSystem, data: Self::Data, _executed: bool) {
+        // In our case the logic than when vetoing the proposal. Let's just call this and
+        // ignore the dispatch result.
+        drop(Self::on_veto_proposal(voting_system, data));
+    }
+
+    fn can_close(_voting_system: Self::VotingSystem, data: Self::Data) -> bool {
+        data.in_favor + data.in_opposition > 0
+    }
+
+    fn passing(_voting_system: Self::VotingSystem, data: Self::Data) -> bool {
+        data.in_favor > data.in_opposition
     }
 }
 

--- a/pallets/organizations/src/tests/mock.rs
+++ b/pallets/organizations/src/tests/mock.rs
@@ -37,10 +37,6 @@ impl RoleBuilder for MockRoles {
     fn apply_as_organization(org_id: &Self::OrganizationId) -> Self::Role {
         MockRoles::ApplyAsOrganization(*org_id)
     }
-
-    fn manage_organization(org_id: &Self::OrganizationId) -> Self::Role {
-        MockRoles::ManageOrganization(*org_id)
-    }
 }
 
 pub type Organizations = Module<Test>;

--- a/pallets/organizations/src/tests/mock.rs
+++ b/pallets/organizations/src/tests/mock.rs
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-use crate::{GenesisConfig, Module, OrganizationDetailsOf, RoleBuilder, Trait};
+use crate::{
+    GenesisConfig, Module, OrganizationDetails, OrganizationDetailsOf, RoleBuilder, Trait,
+};
 use governance_os_pallet_tokens::CurrencyDetails;
 use governance_os_support::{
     mock_runtime_with_currencies,
@@ -80,7 +82,10 @@ impl ExtBuilder {
 
     pub fn with_default_orgs(mut self, nb: u32) -> Self {
         for _ in 0..nb {
-            self.orgs.push(OrganizationDetailsOf::<Test>::default());
+            self.orgs.push(OrganizationDetails {
+                executors: vec![],
+                voting: VotingSystems::None,
+            });
         }
         self
     }

--- a/pallets/organizations/src/tests/mod.rs
+++ b/pallets/organizations/src/tests/mod.rs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-pub mod details;
-pub mod dispatchable;
-pub mod genesis;
-pub mod meta;
-pub mod mock;
+mod details;
+mod dispatchable;
+mod genesis;
+mod meta;
+mod mock;

--- a/pallets/tokens/src/adapter.rs
+++ b/pallets/tokens/src/adapter.rs
@@ -19,7 +19,7 @@ use frame_support::traits::{
     BalanceStatus, Currency, ExistenceRequirement, Get, Imbalance, ReservableCurrency,
     SignedImbalance, WithdrawReasons,
 };
-use governance_os_support::{Currencies, ReservableCurrencies};
+use governance_os_support::traits::{Currencies, ReservableCurrencies};
 use imbalances::{NegativeImbalance, PositiveImbalance};
 use sp_runtime::{
     traits::{Bounded, CheckedAdd, CheckedSub, Zero},

--- a/pallets/tokens/src/benchmarking.rs
+++ b/pallets/tokens/src/benchmarking.rs
@@ -17,7 +17,7 @@
 use crate::*;
 use frame_benchmarking::{account, benchmarks, whitelisted_caller};
 use frame_system::RawOrigin;
-use governance_os_support::{benchmarking::SEED, traits:Currencies};
+use governance_os_support::{benchmarking::SEED, traits::Currencies};
 use sp_runtime::traits::StaticLookup;
 use sp_std::prelude::*;
 

--- a/pallets/tokens/src/benchmarking.rs
+++ b/pallets/tokens/src/benchmarking.rs
@@ -17,7 +17,7 @@
 use crate::*;
 use frame_benchmarking::{account, benchmarks, whitelisted_caller};
 use frame_system::RawOrigin;
-use governance_os_support::{benchmarking::SEED, Currencies};
+use governance_os_support::{benchmarking::SEED, traits:Currencies};
 use sp_runtime::traits::StaticLookup;
 use sp_std::prelude::*;
 

--- a/pallets/tokens/src/currencies.rs
+++ b/pallets/tokens/src/currencies.rs
@@ -16,7 +16,7 @@
 
 use crate::*;
 use frame_support::traits::BalanceStatus;
-use governance_os_support::{Currencies, ReservableCurrencies};
+use governance_os_support::traits::{Currencies, ReservableCurrencies};
 use sp_runtime::{
     traits::{CheckedAdd, CheckedSub, Saturating},
     DispatchError, DispatchResult,

--- a/pallets/tokens/src/lib.rs
+++ b/pallets/tokens/src/lib.rs
@@ -29,7 +29,7 @@ use frame_support::{
     Parameter,
 };
 use frame_system::ensure_signed;
-use governance_os_support::{acl::RoleManager, Currencies};
+use governance_os_support::traits::{Currencies, RoleManager};
 use sp_runtime::{
     traits::{
         AtLeast32BitUnsigned, CheckedAdd, MaybeSerializeDeserialize, Member, StaticLookup, Zero,

--- a/pallets/tokens/src/tests/adapter.rs
+++ b/pallets/tokens/src/tests/adapter.rs
@@ -25,7 +25,7 @@ use frame_support::{
 };
 use governance_os_support::{
     testing::{ALICE, BOB, TEST_TOKEN_ID},
-    Currencies, ReservableCurrencies,
+    traits::{Currencies, ReservableCurrencies},
 };
 
 #[test]

--- a/pallets/tokens/src/tests/currencies.rs
+++ b/pallets/tokens/src/tests/currencies.rs
@@ -22,7 +22,7 @@ use frame_support::{
 };
 use governance_os_support::{
     testing::{primitives::AccountId, ALICE, BOB, TEST_TOKEN_ID, TEST_TOKEN_OWNER},
-    Currencies, ReservableCurrencies,
+    traits::{Currencies, ReservableCurrencies},
 };
 
 #[test]

--- a/pallets/tokens/src/tests/dispatchable.rs
+++ b/pallets/tokens/src/tests/dispatchable.rs
@@ -18,9 +18,9 @@ use super::mock::*;
 use crate::{CurrencyDetails, Error, RoleBuilder};
 use frame_support::{assert_noop, assert_ok};
 use governance_os_support::{
-    acl::{AclError, RoleManager},
+    errors::AclError,
     testing::{ALICE, BOB, TEST_TOKEN_ID, TEST_TOKEN_OWNER},
-    Currencies,
+    traits::{Currencies, RoleManager},
 };
 
 #[test]

--- a/pallets/tokens/src/tests/genesis.rs
+++ b/pallets/tokens/src/tests/genesis.rs
@@ -17,9 +17,8 @@
 use super::mock::*;
 use crate::RoleBuilder;
 use governance_os_support::{
-    acl::RoleManager,
     testing::{ALICE, BOB, TEST_TOKEN_ID, TEST_TOKEN_OWNER},
-    Currencies,
+    traits::{Currencies, RoleManager},
 };
 
 #[test]

--- a/pallets/tokens/src/tests/misc.rs
+++ b/pallets/tokens/src/tests/misc.rs
@@ -19,7 +19,7 @@ use frame_support::{assert_ok, StorageMap};
 use frame_system::Account;
 use governance_os_support::{
     testing::{primitives::AccountId, ALICE, BOB, TEST_TOKEN_ID},
-    Currencies,
+    traits::Currencies,
 };
 
 #[test]

--- a/pallets/tokens/src/tests/mod.rs
+++ b/pallets/tokens/src/tests/mod.rs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-pub mod adapter;
-pub mod currencies;
-pub mod dispatchable;
-pub mod genesis;
-pub mod misc;
-pub mod mock;
+mod adapter;
+mod currencies;
+mod dispatchable;
+mod genesis;
+mod misc;
+mod mock;

--- a/pallets/tokens/src/tests/mod.rs
+++ b/pallets/tokens/src/tests/mod.rs
@@ -19,4 +19,4 @@ mod currencies;
 mod dispatchable;
 mod genesis;
 mod misc;
-mod mock;
+pub mod mock;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -80,7 +80,6 @@ pub enum Role {
     Root,
     TransferCurrency(CurrencyId),
 }
-impl governance_os_support::acl::Role for Role {}
 // `Default` is used for benchmarks. We have to make sure the default role is not
 // root though.
 impl_enum_default!(Role, CreateCurrencies);

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -76,7 +76,6 @@ pub enum Role {
     CreateCurrencies,
     CreateOrganizations,
     ManageCurrency(CurrencyId),
-    ManageOrganization(AccountId),
     ManageRoles,
     Root,
     TransferCurrency(CurrencyId),
@@ -122,9 +121,5 @@ impl governance_os_pallet_organizations::RoleBuilder for Role {
 
     fn apply_as_organization(org_id: &AccountId) -> Role {
         Role::ApplyAsOrganization(org_id.clone())
-    }
-
-    fn manage_organization(org_id: &AccountId) -> Role {
-        Role::ManageOrganization(org_id.clone())
     }
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -30,6 +30,7 @@ governance-os-pallet-organizations = { default-features = false, path = '../pall
 governance-os-pallet-tokens = { default-features = false, path = '../pallets/tokens' }
 governance-os-primitives = { default-features = false, path = '../primitives' }
 governance-os-support = { default-features = false, path = '../support' }
+governance-os-voting = { default-features = false, path = '../voting' }
 pallet-aura = { version = '2.0.0', default-features = false }
 pallet-grandpa = { version = '2.0.0', default-features = false }
 pallet-randomness-collective-flip = { version = '2.0.0', default-features = false }
@@ -45,8 +46,8 @@ sp-inherents = { version = '2.0.0', default-features = false }
 sp-offchain = { version = '2.0.0', default-features = false }
 sp-runtime = { version = '2.0.0', default-features = false }
 sp-session = { version = '2.0.0', default-features = false }
-sp-transaction-pool = { version = '2.0.0', default-features = false }
 sp-std = { version = '2.0.0', default-features = false }
+sp-transaction-pool = { version = '2.0.0', default-features = false }
 sp-version = { version = '2.0.0', default-features = false }
 static_assertions = '1.1.0'
 
@@ -64,6 +65,7 @@ std = [
     'governance-os-pallet-tokens/std',
     'governance-os-primitives/std',
     'governance-os-support/std',
+    'governance-os-voting/std',
     'pallet-aura/std',
     'pallet-grandpa/std',
     'pallet-randomness-collective-flip/std',

--- a/runtime/src/pallets_dorgs.rs
+++ b/runtime/src/pallets_dorgs.rs
@@ -39,6 +39,6 @@ impl governance_os_pallet_organizations::Trait for Runtime {
     type Currencies = Tokens;
     type VotingSystem =
         VotingSystems<Balance, CurrencyId, BlockNumber, Self::Currencies, AccountId>;
-    type ProposalMetadata = ProposalMetadata<AccountId, Balance>;
+    type ProposalMetadata = ProposalMetadata<AccountId, Balance, BlockNumber>;
     type VotingHooks = VotingSystems<Balance, CurrencyId, BlockNumber, Self::Currencies, AccountId>;
 }

--- a/runtime/src/pallets_dorgs.rs
+++ b/runtime/src/pallets_dorgs.rs
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-use crate::{Bylaws, Call, Event, Runtime};
+use crate::{Bylaws, Call, Event, Runtime, Tokens};
 use frame_support::parameter_types;
-use governance_os_primitives::Role;
+use governance_os_primitives::{AccountId, Balance, BlockNumber, CurrencyId, Role};
+use governance_os_voting::{ProposalMetadata, VotingSystems};
 
 parameter_types! {
     pub const MaxRoles: u32 = 50;
@@ -35,4 +36,9 @@ impl governance_os_pallet_organizations::Trait for Runtime {
     type Call = Call;
     type RoleManager = Bylaws;
     type RoleBuilder = Role;
+    type Currencies = Tokens;
+    type VotingSystem =
+        VotingSystems<Balance, CurrencyId, BlockNumber, Self::Currencies, AccountId>;
+    type ProposalMetadata = ProposalMetadata<AccountId, Balance>;
+    type VotingHooks = VotingSystems<Balance, CurrencyId, BlockNumber, Self::Currencies, AccountId>;
 }

--- a/support/src/acl.rs
+++ b/support/src/acl.rs
@@ -17,12 +17,8 @@
 //! A set of common traits to define Access Control lists between pallets and
 //! runtime users.
 
-use frame_support::Parameter;
 use frame_system::{ensure_signed, RawOrigin};
-use sp_runtime::{
-    traits::{MaybeSerializeDeserialize, Member},
-    DispatchError, DispatchResult,
-};
+use sp_runtime::{DispatchError, DispatchResult};
 use sp_std::convert::Into;
 
 pub enum AclError {
@@ -38,10 +34,6 @@ impl Into<DispatchError> for AclError {
         }
     }
 }
-
-/// This defines a role. Roles can be granted to any number of addresses, frozen
-/// (denied for anybody) and granted to everybody at once.
-pub trait Role: Parameter + Member + MaybeSerializeDeserialize + Ord {}
 
 /// This trait can be implemented by a pallet to expose an interface for other pallets to
 /// manage their own role based access control features.

--- a/support/src/currencies.rs
+++ b/support/src/currencies.rs
@@ -37,7 +37,7 @@ use sp_std::{
 /// runtime.
 pub trait Currencies<AccountId> {
     /// The type used to identify currencies
-    type CurrencyId: FullCodec + Eq + PartialEq + Copy + MaybeSerializeDeserialize + Debug;
+    type CurrencyId: FullCodec + Eq + PartialEq + Copy + MaybeSerializeDeserialize + Debug + Default;
 
     /// The balance of an account.
     type Balance: AtLeast32BitUnsigned

--- a/support/src/errors.rs
+++ b/support/src/errors.rs
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-use super::mock::*;
-use governance_os_support::{
-    testing::{ALICE, BOB},
-    traits::RoleManager,
-};
+//! Centralize every error types for the `support` crate here.
 
-#[test]
-fn register_role() {
-    ExtBuilder::default()
-        .with_role(MockRoles::RemarkOnly, None)
-        .with_role(MockRoles::Root, Some(ALICE))
-        .build()
-        .execute_with(|| {
-            assert!(Bylaws::has_role(&ALICE, MockRoles::Root));
-            assert!(!Bylaws::has_role(&BOB, MockRoles::Root));
-            assert!(Bylaws::has_role(&ALICE, MockRoles::RemarkOnly));
-            assert!(Bylaws::has_role(&BOB, MockRoles::RemarkOnly));
-        })
-}
+pub use crate::acl::AclError;

--- a/support/src/lib.rs
+++ b/support/src/lib.rs
@@ -18,14 +18,15 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-pub mod acl;
+mod acl;
+mod currencies;
+mod voting;
+
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
-pub mod currencies;
+pub mod errors;
 pub mod testing;
-pub mod voting;
-
-pub use currencies::{Currencies, ReservableCurrencies};
+pub mod traits;
 
 #[macro_export]
 /// Use this macro to easily implement `Default` for a given enum. This avoids

--- a/support/src/lib.rs
+++ b/support/src/lib.rs
@@ -39,3 +39,16 @@ macro_rules! impl_enum_default {
         }
     };
 }
+
+#[macro_export]
+/// This macro makes it easy to check a result from a function and returning it
+/// if it is an error.
+/// Useful when `?` is not usable, for instance if a function returns a tuple of
+/// a result and something else.
+macro_rules! ensure_not_err {
+    ($res:tt) => {
+        if $res.is_err() {
+            return $res;
+        }
+    };
+}

--- a/support/src/lib.rs
+++ b/support/src/lib.rs
@@ -23,6 +23,7 @@ pub mod acl;
 pub mod benchmarking;
 pub mod currencies;
 pub mod testing;
+pub mod voting;
 
 pub use currencies::{Currencies, ReservableCurrencies};
 

--- a/support/src/testing.rs
+++ b/support/src/testing.rs
@@ -56,7 +56,6 @@ macro_rules! mock_runtime {
         use codec::{Decode, Encode};
         use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types};
         use governance_os_support::{
-            acl::Role,
             impl_enum_default,
             testing::{
                 primitives::{AccountId, CurrencyId},
@@ -134,7 +133,6 @@ macro_rules! mock_runtime {
             CreateOrganizations,
             ApplyAsOrganization(AccountId),
         }
-        impl Role for MockRoles {}
         impl_enum_default!(MockRoles, RemarkOnly);
         impl governance_os_pallet_bylaws::RoleBuilder for MockRoles {
             type Role = MockRoles;

--- a/support/src/testing.rs
+++ b/support/src/testing.rs
@@ -38,6 +38,7 @@ pub mod primitives {
     pub type AccountId = u128;
     pub type Balance = u64;
     pub type CurrencyId = u8;
+    pub type BlockNumber = u64;
 }
 
 #[macro_export]
@@ -58,7 +59,7 @@ macro_rules! mock_runtime {
         use governance_os_support::{
             impl_enum_default,
             testing::{
-                primitives::{AccountId, CurrencyId},
+                primitives::{AccountId, BlockNumber, CurrencyId},
                 AvailableBlockRatio, BlockHashCount, MaximumBlockLength, MaximumBlockWeight, ROOT,
             },
         };
@@ -88,7 +89,7 @@ macro_rules! mock_runtime {
             type Origin = Origin;
             type Call = Call;
             type Index = u64;
-            type BlockNumber = u64;
+            type BlockNumber = BlockNumber;
             type Hash = H256;
             type Hashing = BlakeTwo256;
             type AccountId = AccountId;

--- a/support/src/testing.rs
+++ b/support/src/testing.rs
@@ -133,7 +133,6 @@ macro_rules! mock_runtime {
             ManageCurrency(CurrencyId),
             CreateOrganizations,
             ApplyAsOrganization(AccountId),
-            ManageOrganization(AccountId),
         }
         impl Role for MockRoles {}
         impl_enum_default!(MockRoles, RemarkOnly);

--- a/support/src/traits.rs
+++ b/support/src/traits.rs
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-use super::mock::*;
-use governance_os_support::{
-    testing::{ALICE, BOB},
-    traits::RoleManager,
-};
-
-#[test]
-fn register_role() {
-    ExtBuilder::default()
-        .with_role(MockRoles::RemarkOnly, None)
-        .with_role(MockRoles::Root, Some(ALICE))
-        .build()
-        .execute_with(|| {
-            assert!(Bylaws::has_role(&ALICE, MockRoles::Root));
-            assert!(!Bylaws::has_role(&BOB, MockRoles::Root));
-            assert!(Bylaws::has_role(&ALICE, MockRoles::RemarkOnly));
-            assert!(Bylaws::has_role(&BOB, MockRoles::RemarkOnly));
-        })
-}
+pub use crate::acl::RoleManager;
+pub use crate::currencies::{Currencies, ReservableCurrencies};
+pub use crate::voting::VotingHooks;

--- a/support/src/voting.rs
+++ b/support/src/voting.rs
@@ -16,7 +16,7 @@
 
 //! A set of common traits to voting systems.
 
-use crate::{Currencies, ReservableCurrencies};
+use crate::traits::{Currencies, ReservableCurrencies};
 use sp_runtime::DispatchResult;
 
 /// Called by the host pallet to let the developer implement custom voting actions

--- a/support/src/voting.rs
+++ b/support/src/voting.rs
@@ -16,14 +16,14 @@
 
 //! A set of common traits to voting systems.
 
-use crate::ReservableCurrencies;
+use crate::{Currencies, ReservableCurrencies};
 use frame_support::Parameter;
 use sp_runtime::{
     traits::{MaybeSerializeDeserialize, Member},
     DispatchResult,
 };
 
-pub trait VotingSystem: Parameter + Member + MaybeSerializeDeserialize {}
+pub trait VotingSystem: Parameter + Member + Copy + MaybeSerializeDeserialize {}
 
 /// Called by the host pallet to let the developer implement custom voting actions
 /// according to its own model.
@@ -45,4 +45,13 @@ pub trait VotingHooks {
     /// A proposal is going to be vetoed. Called before any state changes. This is
     /// where you have the possibility to free any funds reserved.
     fn on_veto_proposal(voting_system: Self::VotingSystem, data: Self::Data) -> DispatchResult;
+
+    /// Handle an incoming vote. Returns a result and some updated metadata.
+    fn on_decide_on_proposal(
+        voting_system: Self::VotingSystem,
+        data: Self::Data,
+        voter: &Self::AccountId,
+        power: <Self::Currencies as Currencies<Self::AccountId>>::Balance,
+        in_support: bool,
+    ) -> (DispatchResult, Self::Data);
 }

--- a/support/src/voting.rs
+++ b/support/src/voting.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! A set of common traits to voting systems.
+
+use crate::ReservableCurrencies;
+use frame_support::Parameter;
+use sp_runtime::{
+    traits::{MaybeSerializeDeserialize, Member},
+    DispatchResult,
+};
+
+pub trait VotingSystem: Parameter + Member + MaybeSerializeDeserialize {}
+
+/// Called by the host pallet to let the developer implement custom voting actions
+/// according to its own model.
+pub trait VotingHooks {
+    type AccountId;
+    type OrganizationId;
+    type VotingSystem: VotingSystem;
+    type Currencies: ReservableCurrencies<Self::AccountId>;
+    type Data;
+
+    /// Somebody is creating a proposal. Called before any state changes. This
+    /// is where you have the ability to try and reserve a certain amount of coins
+    /// for instance.
+    fn on_creating_proposal(
+        voting_system: Self::VotingSystem,
+        creator: &Self::AccountId,
+    ) -> (DispatchResult, Self::Data);
+}

--- a/support/src/voting.rs
+++ b/support/src/voting.rs
@@ -41,4 +41,8 @@ pub trait VotingHooks {
         voting_system: Self::VotingSystem,
         creator: &Self::AccountId,
     ) -> (DispatchResult, Self::Data);
+
+    /// A proposal is going to be vetoed. Called before any state changes. This is
+    /// where you have the possibility to free any funds reserved.
+    fn on_veto_proposal(voting_system: Self::VotingSystem, data: Self::Data) -> DispatchResult;
 }

--- a/support/src/voting.rs
+++ b/support/src/voting.rs
@@ -54,4 +54,21 @@ pub trait VotingHooks {
         power: <Self::Currencies as Currencies<Self::AccountId>>::Balance,
         in_support: bool,
     ) -> (DispatchResult, Self::Data);
+
+    /// Return wether we should enable calls to closing the proposal. Closing a proposal
+    /// means executing it if it passed and then cleaning the storage.
+    fn can_close(voting_system: Self::VotingSystem, data: Self::Data) -> bool;
+
+    /// Return if a proposal is passing. If it is, it will likely be executed in the same
+    /// transaction and then closed.
+    fn passing(voting_system: Self::VotingSystem, data: Self::Data) -> bool;
+
+    /// Called before cleaning the storage related to a proposal but after its eventual
+    /// execution.
+    ///
+    /// **NOTE**: we do not allow this call to return a DispatchResult or potential error
+    /// as it happens after the proposal has been executed. Failing at this stage would
+    /// mean that there is a likelyhood for a proposal to be executed twice which is definitely
+    /// not something that we want.
+    fn on_close_proposal(voting_system: Self::VotingSystem, data: Self::Data, executed: bool);
 }

--- a/support/src/voting.rs
+++ b/support/src/voting.rs
@@ -17,20 +17,14 @@
 //! A set of common traits to voting systems.
 
 use crate::{Currencies, ReservableCurrencies};
-use frame_support::Parameter;
-use sp_runtime::{
-    traits::{MaybeSerializeDeserialize, Member},
-    DispatchResult,
-};
-
-pub trait VotingSystem: Parameter + Member + Copy + MaybeSerializeDeserialize {}
+use sp_runtime::DispatchResult;
 
 /// Called by the host pallet to let the developer implement custom voting actions
 /// according to its own model.
 pub trait VotingHooks {
     type AccountId;
     type OrganizationId;
-    type VotingSystem: VotingSystem;
+    type VotingSystem;
     type Currencies: ReservableCurrencies<Self::AccountId>;
     type Data;
 

--- a/types.json
+++ b/types.json
@@ -10,6 +10,13 @@
     "data": "AccountData"
   },
   "Address": "AccountId",
+  "CoinBasedVotingParameters": {
+    "voting_currency": "CurrencyId",
+    "creation_fee": "Balance",
+    "min_quorum": "u32",
+    "min_participation": "u32",
+    "ttl": "BlockNumber"
+  },
   "CurrencyDetails": {
     "owner": "AccountId",
     "transferable": "bool"
@@ -21,13 +28,43 @@
     }
   },
   "LookupSource": "AccountId",
+  "OrganizationsCounter": "u32",
+  "OrganizationDetails": {
+    "executors": "Vec<AccountId>",
+    "voting": "VotingSystem"
+  },
+  "OrganizationDetailsOf": "OrganizationDetails",
+  "Proposal": {
+    "org": "AccountId",
+    "call": "Vec<u8>",
+    "metadata": "ProposalMetadata",
+    "voting": "VotingSystem"
+  },
+  "ProposalId": "Hash",
+  "ProposalIdOf": "ProposalId",
+  "ProposalMetadata": {
+    "votes": "BTreeMap<AccountId, (Balance, bool)>",
+    "favorable": "Balance",
+    "against": "Balance",
+    "creator": "AccountId",
+    "expiry": "BlockNumber"
+  },
+  "ProposalOf": "Proposal",
   "Role": {
     "_enum": {
+      "ApplyAsOrganization": "AccountId",
       "CreateCurrencies": "Null",
+      "CreateOrganizations": "Null",
       "ManageCurrencies": "CurrencyId",
       "ManageRoles": "Null",
       "Root": "Null",
       "TransferCurrency": "CurrencyId"
+    }
+  },
+  "VotingSystem": {
+    "_enum": {
+      "None": "Null",
+      "CoinBased": "CoinBasedVotingParameters"
     }
   }
 }

--- a/voting/Cargo.toml
+++ b/voting/Cargo.toml
@@ -1,0 +1,32 @@
+
+[package]
+edition = '2018'
+license = 'Apache 2.0'
+name = 'governance-os-voting'
+version = '0.1.0'
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+# alias "parity-scale-code" to "codec"
+[dependencies.codec]
+default-features = false
+features = ['derive']
+package = 'parity-scale-codec'
+version = '1.3.4'
+
+[dependencies]
+governance-os-support = { path = '../support', default-features = false }
+serde = { version = '1.0.116', optional = true }
+sp-runtime = { version = '2.0.0', default-features = false }
+sp-std = { version = '2.0.0', default-features = false }
+
+[features]
+default = ['std']
+std = [
+    'codec/std',
+    'governance-os-support/std',
+    'serde',
+    'sp-runtime/std',
+    'sp-std/std',
+]

--- a/voting/Cargo.toml
+++ b/voting/Cargo.toml
@@ -21,6 +21,14 @@ serde = { version = '1.0.116', optional = true }
 sp-runtime = { version = '2.0.0', default-features = false }
 sp-std = { version = '2.0.0', default-features = false }
 
+[dev-dependencies]
+frame-support = '2.0.0'
+frame-system = '2.0.0'
+governance-os-pallet-bylaws = { path = '../pallets/bylaws' }
+governance-os-pallet-tokens = { path = '../pallets/tokens' }
+sp-core = '2.0.0'
+sp-io = '2.0.0'
+
 [features]
 default = ['std']
 std = [

--- a/voting/src/lib.rs
+++ b/voting/src/lib.rs
@@ -21,7 +21,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
-use governance_os_support::{voting::VotingHooks, Currencies, ReservableCurrencies};
+use governance_os_support::traits::{Currencies, ReservableCurrencies, VotingHooks};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_runtime::{

--- a/voting/src/lib.rs
+++ b/voting/src/lib.rs
@@ -95,14 +95,6 @@ pub enum VotingSystems<Balance, CurrencyId, BlockNumber, Currencies, AccountId> 
     _Phantom(marker::PhantomData<(AccountId, Currencies)>),
 }
 
-impl<Balance, CurrencyId, BlockNumber, Currencies, AccountId> Default
-    for VotingSystems<Balance, CurrencyId, BlockNumber, Currencies, AccountId>
-{
-    fn default() -> Self {
-        Self::None
-    }
-}
-
 /// Parameters for the coin based voting system.
 #[derive(Eq, PartialEq, RuntimeDebug, Encode, Decode, Copy, Clone)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]

--- a/voting/src/lib.rs
+++ b/voting/src/lib.rs
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! This crate is in charge of containing voting systems as supported by the Governance OS.
+//! They were made to integrate nicely with our own `organizations` pallet but should be reusable
+//! by other projects as well.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::{Decode, Encode};
+use governance_os_support::{voting::VotingHooks, Currencies, ReservableCurrencies};
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+use sp_runtime::{DispatchResult, RuntimeDebug};
+use sp_std::{collections::btree_map::BTreeMap, marker};
+
+/// Metadata used and managed by all our voting systems. Need to be passed to their functions and
+/// persisted in storage.
+#[derive(Eq, PartialEq, RuntimeDebug, Encode, Decode, Clone, Default)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct ProposalMetadata<AccountId, Balance>
+where
+    AccountId: Ord,
+{
+    /// A map of voter => (coins, in favor or against)
+    pub votes: BTreeMap<AccountId, (Balance, bool)>,
+    /// Cached value of how many coins support the proposal
+    pub favorable: Balance,
+    /// Cached value of how many coins oppose the proposal
+    pub against: Balance,
+}
+
+/// This enum is in charge of representing and handling all existing voting systems.
+#[derive(Eq, PartialEq, RuntimeDebug, Encode, Decode, Copy, Clone)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum VotingSystems<Balance, CurrencyId, BlockNumber, Currencies, AccountId> {
+    /// An empty voting system. Useful if someone wants to create an organization
+    /// managed by other things than votes.
+    None,
+
+    /// A simple coin based voting system where people vote by reserving some of their own coins.
+    /// Our implementation has the following specificities:
+    /// - creating a proposal requires the creator to block some of their coins to avoid spam; the coins
+    ///   are considered in support of the proposal.
+    /// - in the event that someone makes multiple votes we consider future votes as updates of the previous
+    ///   ones; this means that weight and locked coins are recomputed every time.
+    /// - a proposal passes once a configurable quorum is met (for instance, 50% of the coins need to agree)
+    /// - a minimum quorum is in place which represents the minimum amount of coins a proposal need to be even
+    ///   considered
+    /// - a voting period duration is configured; after it is elapsed proposals can be closed by anyone
+    CoinBased(CoinBasedVotingParameters<Balance, CurrencyId, BlockNumber>),
+
+    /// We need this entry for accepting a `Currencies` and a `AccountId` type.
+    _Phantom(marker::PhantomData<(AccountId, Currencies)>),
+}
+impl<Balance, CurrencyId, BlockNumber, Currencies, AccountId> Default
+    for VotingSystems<Balance, CurrencyId, BlockNumber, Currencies, AccountId>
+{
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// Parameters for the coin based voting system.
+#[derive(Eq, PartialEq, RuntimeDebug, Encode, Decode, Copy, Clone)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct CoinBasedVotingParameters<Balance, CurrencyId, BlockNumber> {
+    /// What currency is used to represent vote inside the organization.
+    pub voting_currency: CurrencyId,
+    /// How much one has to lock to create a proposal and fight spam.
+    pub creation_fee: Balance,
+    /// What percentage of coins need to be in favor of a proposal for it to pass.
+    /// We will then use it via a `perbill::from_percent` call.
+    pub min_quorum: Balance,
+    /// What percentage of coins need to participate before a quorum is reached.
+    /// We will then use it via a `perbill::from_percent` call.
+    pub min_participation: Balance,
+    /// After how many blocks will a proposal be considered failed if it doesn't reach
+    /// a favorable outcome.
+    pub ttl: BlockNumber,
+}
+
+impl<AccountId, BlockNumber, C> VotingHooks
+    for VotingSystems<C::Balance, C::CurrencyId, BlockNumber, C, AccountId>
+where
+    AccountId: Ord,
+    C: ReservableCurrencies<AccountId> + Currencies<AccountId>,
+{
+    type AccountId = AccountId;
+    type OrganizationId = AccountId;
+    type VotingSystem = Self;
+    type Currencies = C;
+    type Data = ProposalMetadata<AccountId, C::Balance>;
+
+    fn on_creating_proposal(
+        voting_system: Self::VotingSystem,
+        creator: &Self::AccountId,
+    ) -> (DispatchResult, Self::Data) {
+        unimplemented!()
+    }
+
+    fn on_veto_proposal(voting_system: Self::VotingSystem, data: Self::Data) -> DispatchResult {
+        unimplemented!()
+    }
+
+    fn on_decide_on_proposal(
+        voting_system: Self::VotingSystem,
+        data: Self::Data,
+        voter: &Self::AccountId,
+        power: <Self::Currencies as Currencies<Self::AccountId>>::Balance,
+        in_support: bool,
+    ) -> (DispatchResult, Self::Data) {
+        unimplemented!()
+    }
+
+    fn can_close(voting_system: Self::VotingSystem, data: Self::Data) -> bool {
+        unimplemented!()
+    }
+
+    fn passing(voting_system: Self::VotingSystem, data: Self::Data) -> bool {
+        unimplemented!()
+    }
+
+    fn on_close_proposal(voting_system: Self::VotingSystem, data: Self::Data, executed: bool) {
+        unimplemented!()
+    }
+}

--- a/voting/src/tests/coin_based.rs
+++ b/voting/src/tests/coin_based.rs
@@ -22,8 +22,7 @@ use governance_os_support::{
         primitives::{AccountId, Balance, BlockNumber, CurrencyId},
         ALICE, BOB, CHARLIE, TEST_TOKEN_ID,
     },
-    voting::VotingHooks,
-    Currencies, ReservableCurrencies,
+    traits::{Currencies, ReservableCurrencies, VotingHooks},
 };
 
 fn mock_system() -> MockVotingSystems {

--- a/voting/src/tests/coin_based.rs
+++ b/voting/src/tests/coin_based.rs
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::mock::{ExtBuilder, MockVotingSystems, Tokens};
+use crate::{CoinBasedVotingParameters, ProposalMetadata, VotingErrors};
+use frame_support::assert_ok;
+use governance_os_support::{
+    testing::{
+        primitives::{AccountId, Balance, BlockNumber, CurrencyId},
+        ALICE, BOB, CHARLIE, TEST_TOKEN_ID,
+    },
+    voting::VotingHooks,
+    Currencies, ReservableCurrencies,
+};
+
+fn mock_system() -> MockVotingSystems {
+    MockVotingSystems::CoinBased(
+        CoinBasedVotingParameters::<Balance, CurrencyId, BlockNumber> {
+            voting_currency: TEST_TOKEN_ID,
+            creation_fee: 10,
+            min_quorum: 50,        // 50% min approval
+            min_participation: 20, // 20% participation rate
+            ttl: 10,
+        },
+    )
+}
+
+#[test]
+fn on_create_proposal_returns_correct_metadata_and_reserve_fee() {
+    ExtBuilder::default()
+        .hundred_for_alice()
+        .build()
+        .execute_with(|| {
+            let (res, data) = MockVotingSystems::on_create_proposal(mock_system(), &ALICE, 0);
+
+            assert_eq!(res, Ok(()));
+
+            assert_eq!(data.creator, ALICE);
+            assert_eq!(data.favorable, 10);
+            assert_eq!(data.against, 0);
+            assert_eq!(data.expiry, 10);
+            assert_eq!(data.votes.len(), 1);
+            assert!(data.votes.contains_key(&ALICE));
+            assert_eq!(data.votes.get(&ALICE), Some(&(10, true)));
+
+            assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, &ALICE), 10);
+        })
+}
+
+#[test]
+fn on_veto_proposal_free_all_funds() {
+    ExtBuilder::default().build().execute_with(|| {
+        // Create a specific structure with a few votes
+        let mut metadata: ProposalMetadata<AccountId, Balance, BlockNumber> = Default::default();
+        metadata.votes.insert(ALICE, (10, true));
+        metadata.votes.insert(BOB, (5, false));
+        metadata.votes.insert(CHARLIE, (10, true));
+        metadata
+            .votes
+            .iter()
+            .for_each(|(account, (val, _support))| {
+                assert_ok!(<Tokens as Currencies<AccountId>>::mint(
+                    TEST_TOKEN_ID,
+                    account,
+                    *val
+                ));
+                assert_ok!(Tokens::reserve(TEST_TOKEN_ID, account, *val));
+            });
+
+        assert_ok!(MockVotingSystems::on_veto_proposal(
+            mock_system(),
+            metadata.clone()
+        ));
+
+        metadata
+            .votes
+            .iter()
+            .for_each(|(account, (val, _support))| {
+                assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, account), 0);
+                assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, account), *val);
+            });
+    })
+}
+
+macro_rules! test_on_decide_on_proposal_simple {
+    ($test_name:ident, $support:tt) => {
+        #[test]
+        fn $test_name() {
+            ExtBuilder::default()
+                .hundred_for_alice()
+                .build()
+                .execute_with(|| {
+                    let (res, data) = MockVotingSystems::on_decide_on_proposal(
+                        mock_system(),
+                        Default::default(),
+                        &ALICE,
+                        50,
+                        $support,
+                    );
+
+                    assert_ok!(res);
+                    assert_eq!(data.votes.get(&ALICE), Some(&(50, $support)));
+                })
+        }
+    };
+}
+
+macro_rules! test_on_decide_on_proposal_updates {
+    ($test_name:ident, $old_support:tt, $old_weight:tt, $new_support:tt, $new_weight:tt) => {
+        #[test]
+        fn $test_name() {
+            ExtBuilder::default()
+                .hundred_for_alice()
+                .build()
+                .execute_with(|| {
+                    let (res, data) = MockVotingSystems::on_decide_on_proposal(
+                        mock_system(),
+                        Default::default(),
+                        &ALICE,
+                        $old_weight,
+                        $old_support,
+                    );
+
+                    assert_ok!(res);
+                    assert_eq!(data.votes.get(&ALICE), Some(&($old_weight, $old_support)));
+
+                    let (res, data) = MockVotingSystems::on_decide_on_proposal(
+                        mock_system(),
+                        data,
+                        &ALICE,
+                        $new_weight,
+                        $new_support,
+                    );
+
+                    assert_ok!(res);
+                    assert_eq!(data.votes.get(&ALICE), Some(&($new_weight, $new_support)));
+                })
+        }
+    };
+}
+
+test_on_decide_on_proposal_simple!(test_on_decide_on_proposal_favorable, true);
+test_on_decide_on_proposal_simple!(test_on_decide_on_proposal_against, false);
+
+test_on_decide_on_proposal_updates!(
+    test_on_decide_on_proposal_increase_against,
+    false,
+    10,
+    false,
+    20
+);
+test_on_decide_on_proposal_updates!(
+    test_on_decide_on_proposal_decrease_against,
+    false,
+    20,
+    false,
+    10
+);
+test_on_decide_on_proposal_updates!(
+    test_on_decide_on_proposal_increase_favorable,
+    true,
+    10,
+    true,
+    20
+);
+test_on_decide_on_proposal_updates!(
+    test_on_decide_on_proposal_decrease_favorable,
+    true,
+    20,
+    true,
+    10
+);
+test_on_decide_on_proposal_updates!(
+    test_on_decide_on_proposal_change_against_to_favorable,
+    false,
+    10,
+    true,
+    20
+);
+test_on_decide_on_proposal_updates!(
+    test_on_decide_on_proposal_change_favorable_to_against,
+    true,
+    10,
+    false,
+    20
+);
+
+#[test]
+fn on_decide_on_proposal_creator_cannot_free_creation_fee_in_advance() {
+    ExtBuilder::default()
+        .hundred_for_alice()
+        .build()
+        .execute_with(|| {
+            let mut metadata: ProposalMetadata<AccountId, Balance, BlockNumber> =
+                Default::default();
+            metadata.votes.insert(ALICE, (10, true));
+            metadata.creator = ALICE;
+            assert_ok!(Tokens::reserve(TEST_TOKEN_ID, &ALICE, 10));
+
+            let (res, data) = MockVotingSystems::on_decide_on_proposal(
+                mock_system(),
+                metadata.clone(),
+                &ALICE,
+                5,
+                true,
+            );
+            assert_eq!(res, Err(VotingErrors::UnderCreationFee.into()));
+            assert_eq!(data, metadata);
+        })
+}
+
+#[test]
+fn passing_if_quorum_and_participation_criteria_met() {
+    ExtBuilder::default()
+        .hundred_for_alice()
+        .build()
+        .execute_with(|| {
+            assert!(MockVotingSystems::passing(
+                mock_system(),
+                ProposalMetadata {
+                    favorable: 50,
+                    against: 10,
+                    ..Default::default()
+                }
+            ))
+        })
+}
+
+#[test]
+fn not_passing_if_quorum_is_not_met() {
+    ExtBuilder::default()
+        .hundred_for_alice()
+        .build()
+        .execute_with(|| {
+            // Note how the total number of votes is 21. This allows us to test cases where
+            // the Perbill call is rounding things up or down.
+            assert!(!MockVotingSystems::passing(
+                mock_system(),
+                ProposalMetadata {
+                    favorable: 10,
+                    against: 11,
+                    ..Default::default()
+                }
+            ))
+        })
+}
+
+#[test]
+fn not_passing_if_participation_not_met() {
+    ExtBuilder::default()
+        .hundred_for_alice()
+        .build()
+        .execute_with(|| {
+            // Min participation is 20 tokens, we have 11
+            assert!(!MockVotingSystems::passing(
+                mock_system(),
+                ProposalMetadata {
+                    favorable: 6,
+                    against: 5,
+                    ..Default::default()
+                }
+            ))
+        })
+}
+
+#[test]
+fn can_close_if_passing() {
+    ExtBuilder::default()
+        .hundred_for_alice()
+        .build()
+        .execute_with(|| {
+            assert!(MockVotingSystems::can_close(
+                mock_system(),
+                ProposalMetadata {
+                    favorable: 50,
+                    against: 10,
+                    expiry: 1, // Proposal not yet expired
+                    ..Default::default()
+                },
+                0
+            ))
+        })
+}
+
+#[test]
+fn can_close_if_failed_but_ttl_expired() {
+    ExtBuilder::default()
+        .hundred_for_alice()
+        .build()
+        .execute_with(|| {
+            assert!(MockVotingSystems::can_close(
+                mock_system(),
+                ProposalMetadata {
+                    favorable: 10,
+                    against: 50,
+                    expiry: 1,
+                    ..Default::default()
+                },
+                10 // Late enough so that proposal expire
+            ))
+        })
+}
+
+#[test]
+fn can_not_close_if_failing_but_not_ttl_expired() {
+    ExtBuilder::default()
+        .hundred_for_alice()
+        .build()
+        .execute_with(|| {
+            assert!(!MockVotingSystems::can_close(
+                mock_system(),
+                ProposalMetadata {
+                    favorable: 10,
+                    against: 50,
+                    expiry: 1,
+                    ..Default::default()
+                },
+                0 // Too eearly for expiry
+            ))
+        })
+}
+
+#[test]
+fn on_close_proposal_free_all_funds() {
+    ExtBuilder::default().build().execute_with(|| {
+        // Create a specific structure with a few votes
+        let mut metadata: ProposalMetadata<AccountId, Balance, BlockNumber> = Default::default();
+        metadata.votes.insert(ALICE, (10, true));
+        metadata.votes.insert(BOB, (5, false));
+        metadata.votes.insert(CHARLIE, (10, true));
+        metadata
+            .votes
+            .iter()
+            .for_each(|(account, (val, _support))| {
+                assert_ok!(<Tokens as Currencies<AccountId>>::mint(
+                    TEST_TOKEN_ID,
+                    account,
+                    *val
+                ));
+                assert_ok!(Tokens::reserve(TEST_TOKEN_ID, account, *val));
+            });
+
+        assert_ok!(MockVotingSystems::on_close_proposal(
+            mock_system(),
+            metadata.clone(),
+            false
+        ));
+
+        metadata
+            .votes
+            .iter()
+            .for_each(|(account, (val, _support))| {
+                assert_eq!(Tokens::reserved_balance(TEST_TOKEN_ID, account), 0);
+                assert_eq!(Tokens::free_balance(TEST_TOKEN_ID, account), *val);
+            });
+    })
+}

--- a/voting/src/tests/metadata.rs
+++ b/voting/src/tests/metadata.rs
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::ProposalMetadata;
+use governance_os_support::testing::primitives::{AccountId, Balance, BlockNumber};
+
+#[test]
+fn default_sets_everything_to_zero() {
+    let data: ProposalMetadata<AccountId, Balance, BlockNumber> = Default::default();
+    assert_eq!(data.against, 0);
+    assert_eq!(data.favorable, 0);
+    assert_eq!(data.votes.len(), 0);
+}

--- a/voting/src/tests/mock.rs
+++ b/voting/src/tests/mock.rs
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::VotingSystems;
+use governance_os_pallet_tokens::CurrencyDetails;
+use governance_os_support::{
+    mock_runtime_with_currencies,
+    testing::{ALICE, TEST_TOKEN_ID, TEST_TOKEN_OWNER},
+};
+
+mock_runtime_with_currencies!(Test);
+
+pub type MockVotingSystems = VotingSystems<Balance, CurrencyId, BlockNumber, Tokens, AccountId>;
+
+pub struct ExtBuilder {
+    endowed_accounts: Vec<(CurrencyId, AccountId, Balance)>,
+}
+
+impl Default for ExtBuilder {
+    fn default() -> Self {
+        Self {
+            endowed_accounts: vec![],
+        }
+    }
+}
+
+impl ExtBuilder {
+    pub fn hundred_for_alice(mut self) -> Self {
+        self.endowed_accounts.push((TEST_TOKEN_ID, ALICE, 100));
+        self
+    }
+
+    pub fn build(self) -> sp_io::TestExternalities {
+        let mut t = frame_system::GenesisConfig::default()
+            .build_storage::<Test>()
+            .unwrap();
+
+        governance_os_pallet_tokens::GenesisConfig::<Test> {
+            endowed_accounts: self.endowed_accounts,
+            currency_details: vec![(
+                TEST_TOKEN_ID,
+                CurrencyDetails {
+                    owner: TEST_TOKEN_OWNER,
+                    transferable: true,
+                },
+            )],
+        }
+        .assimilate_storage(&mut t)
+        .unwrap();
+
+        let mut ext = sp_io::TestExternalities::new(t);
+        ext.execute_with(|| System::set_block_number(1));
+        ext
+    }
+}

--- a/voting/src/tests/mod.rs
+++ b/voting/src/tests/mod.rs
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod coin_based;
+pub mod metadata;
+pub mod mock;
+pub mod none;

--- a/voting/src/tests/mod.rs
+++ b/voting/src/tests/mod.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-pub mod coin_based;
-pub mod metadata;
-pub mod mock;
-pub mod none;
+mod coin_based;
+mod metadata;
+mod mock;
+mod none;

--- a/voting/src/tests/none.rs
+++ b/voting/src/tests/none.rs
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::mock::{ExtBuilder, MockVotingSystems};
+use crate::{ProposalMetadata, VotingErrors};
+use frame_support::assert_noop;
+use governance_os_support::{
+    testing::{
+        primitives::{AccountId, Balance, BlockNumber},
+        ALICE,
+    },
+    voting::VotingHooks,
+};
+
+#[test]
+fn on_create_proposal_error_with_empty_metadata() {
+    ExtBuilder::default().build().execute_with(|| {
+        let (res, data) = MockVotingSystems::on_create_proposal(MockVotingSystems::None, &ALICE, 0);
+        assert_eq!(res, Err(VotingErrors::NotAVotingSystem.into()));
+        assert_eq!(data, Default::default());
+    })
+}
+
+#[test]
+fn on_veto_proposal_error() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            MockVotingSystems::on_veto_proposal(MockVotingSystems::None, Default::default()),
+            VotingErrors::NotAVotingSystem
+        );
+    })
+}
+
+#[test]
+fn on_decide_on_proposal_error_no_data_change() {
+    ExtBuilder::default().build().execute_with(|| {
+        let metadata: ProposalMetadata<AccountId, Balance, BlockNumber> = Default::default();
+        let (res, data) = MockVotingSystems::on_decide_on_proposal(
+            MockVotingSystems::None,
+            metadata.clone(),
+            &ALICE,
+            0,
+            true,
+        );
+        assert_eq!(data, metadata); // No changes
+        assert_eq!(res, Err(VotingErrors::NotAVotingSystem.into()));
+    })
+}
+
+#[test]
+fn can_close_is_false() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert!(!MockVotingSystems::can_close(
+            MockVotingSystems::None,
+            Default::default(),
+            0,
+        ));
+    })
+}
+
+#[test]
+fn passing_is_false() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert!(!MockVotingSystems::passing(
+            MockVotingSystems::None,
+            Default::default()
+        ));
+    })
+}
+
+#[test]
+fn on_close_proposal_error() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            MockVotingSystems::on_close_proposal(
+                MockVotingSystems::None,
+                Default::default(),
+                false
+            ),
+            VotingErrors::NotAVotingSystem
+        );
+    })
+}

--- a/voting/src/tests/none.rs
+++ b/voting/src/tests/none.rs
@@ -22,7 +22,7 @@ use governance_os_support::{
         primitives::{AccountId, Balance, BlockNumber},
         ALICE,
     },
-    voting::VotingHooks,
+    traits::VotingHooks,
 };
 
 #[test]


### PR DESCRIPTION
Fix #7.
Fix #8.

- simplify orgs permissioning model
- fix initial docstring
- creating proposals
- proposals vetoing
- proposal type alias
- voting hooks
- closing and executing proposals
- fix enum traits pattern
- make everything compile and add mock voting code
- implement production voting system
- use prod voting system in tests and mocks as well
- code cleanups
- pub mods are useless in tests
- reorg support crate
- create json types
- use options instead of defaults in storage
