### PR TITLE
lockable currencies

### DIFF
--- a/pallets/tokens/src/account_data.rs
+++ b/pallets/tokens/src/account_data.rs
@@ -33,6 +33,8 @@ pub struct AccountCurrencyData<Balance> {
     /// This balance is a 'reserve' balance that other subsystems use in order to set aside tokens
     /// that are still 'owned' by the account holder, but which are suspendable.
     pub reserved: Balance,
+    /// Balance under which the free balance may never drop below.
+    pub frozen: Balance,
 }
 impl<Balance: Saturating + Copy> AccountCurrencyData<Balance> {
     /// Computes and return the total balance, including reserved funds.

--- a/pallets/tokens/src/adapter.rs
+++ b/pallets/tokens/src/adapter.rs
@@ -21,12 +21,12 @@ use crate::{
 };
 use frame_support::{
     traits::{
-        BalanceStatus, Currency, ExistenceRequirement, Get, Imbalance, ReservableCurrency,
-        SignedImbalance, WithdrawReasons,
+        BalanceStatus, Currency, ExistenceRequirement, Get, Imbalance, LockIdentifier,
+        LockableCurrency, ReservableCurrency, SignedImbalance, WithdrawReasons,
     },
     StorageMap,
 };
-use governance_os_support::traits::{Currencies, ReservableCurrencies};
+use governance_os_support::traits::{Currencies, LockableCurrencies, ReservableCurrencies};
 use sp_runtime::{
     traits::{Bounded, CheckedAdd, CheckedSub, Zero},
     DispatchError, DispatchResult,
@@ -237,5 +237,47 @@ where
             amount,
             status,
         )
+    }
+}
+
+impl<Pallet, GetCurrencyId> LockableCurrency<Pallet::AccountId>
+    for NativeCurrencyAdapter<Pallet, GetCurrencyId>
+where
+    Pallet: Trait,
+    GetCurrencyId: Get<Pallet::CurrencyId>,
+{
+    type Moment = Pallet::BlockNumber;
+    type MaxLocks = ();
+
+    fn set_lock(
+        id: LockIdentifier,
+        who: &Pallet::AccountId,
+        amount: Self::Balance,
+        _reasons: WithdrawReasons,
+    ) {
+        drop(Module::<Pallet>::set_lock(
+            GetCurrencyId::get(),
+            id,
+            who,
+            amount,
+        ))
+    }
+
+    fn extend_lock(
+        id: LockIdentifier,
+        who: &Pallet::AccountId,
+        amount: Self::Balance,
+        _reasons: WithdrawReasons,
+    ) {
+        drop(Module::<Pallet>::extend_lock(
+            GetCurrencyId::get(),
+            id,
+            who,
+            amount,
+        ))
+    }
+
+    fn remove_lock(id: LockIdentifier, who: &Pallet::AccountId) {
+        drop(Module::<Pallet>::remove_lock(GetCurrencyId::get(), id, who))
     }
 }

--- a/pallets/tokens/src/currencies.rs
+++ b/pallets/tokens/src/currencies.rs
@@ -218,6 +218,9 @@ impl<T: Trait> Module<T> {
                     if mutation.frozen(who) < amount {
                         mutation.add_frozen(who, amount)?;
                     }
+
+                    // A new lock is being created, inc the system ref
+                    frame_system::Module::<T>::inc_ref(who);
                 } else {
                     // We are overwriting an existing lock
                     let existing_lock = maybe_existing_lock
@@ -279,6 +282,8 @@ impl<T: Trait> LockableCurrencies<T::AccountId> for Module<T> {
         who: &T::AccountId,
     ) -> DispatchResult {
         Locks::<T>::remove((who, currency_id), lock_id);
+        frame_system::Module::<T>::dec_ref(who);
+
         let highest_lock_value = Locks::<T>::iter_prefix((who, currency_id)).fold(
             Zero::zero(),
             |acc, (_lock_id, lock_val)| {

--- a/pallets/tokens/src/currencies.rs
+++ b/pallets/tokens/src/currencies.rs
@@ -130,7 +130,7 @@ impl<T: Trait> ReservableCurrencies<T::AccountId> for Module<T> {
         who: &T::AccountId,
         amount: Self::Balance,
     ) -> DispatchResult {
-        // We do not require the asset to be transferable, it is assume that it is acceptable
+        // We do not require the asset to be transferable, it is assumed that it is acceptable
         // to reserve non transferable currencies
         let mut mutation = Mutation::<T>::new_for_currency(currency_id);
         mutation.sub_free_balance(who, amount)?;

--- a/pallets/tokens/src/lib.rs
+++ b/pallets/tokens/src/lib.rs
@@ -188,6 +188,8 @@ decl_error! {
         BalanceOverflow,
         /// There are not enough coins inside the balance of the user to perform the action
         BalanceTooLow,
+        /// Some of the balance you are trying to withdraw is locked.
+        BalanceLockTriggered,
         /// The currency ID is already used by another currency
         CurrencyAlreadyExists,
         /// This owner(s) of this currency have disabled transfers

--- a/pallets/tokens/src/lib.rs
+++ b/pallets/tokens/src/lib.rs
@@ -25,7 +25,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::{
-    decl_error, decl_event, decl_module, decl_storage, weights::Weight, Parameter,
+    decl_error, decl_event, decl_module, decl_storage, traits::LockIdentifier, weights::Weight,
+    Parameter,
 };
 use frame_system::ensure_signed;
 use governance_os_support::traits::{Currencies, RoleManager};
@@ -120,6 +121,7 @@ decl_storage! {
         /// Store the balances holded by an account. By storing the balances under an account (VS storing
         /// the accounts under the currency ids) we can enumerate the tokens holded by an account if needed.
         pub Balances get(fn balances): double_map hasher(blake2_128_concat) T::AccountId, hasher(blake2_128_concat) T::CurrencyId => AccountCurrencyData<T::Balance>;
+        pub Locks get(fn locks): double_map hasher(blake2_128_concat) (T::AccountId, T::CurrencyId), hasher(blake2_128_concat) LockIdentifier => T::Balance;
         pub TotalIssuances get(fn total_issuances) build(|config: &GenesisConfig<T>| {
             config
                 .endowed_accounts

--- a/pallets/tokens/src/lib.rs
+++ b/pallets/tokens/src/lib.rs
@@ -150,6 +150,7 @@ decl_storage! {
 
             config.endowed_accounts.iter().for_each(|(currency_id, account_id, initial_balance)| {
                 Balances::<T>::mutate(account_id, *currency_id, |d| d.free = *initial_balance);
+                frame_system::Module::<T>::inc_ref(&account_id);
             });
         })
     }

--- a/pallets/tokens/src/mutations.rs
+++ b/pallets/tokens/src/mutations.rs
@@ -173,6 +173,11 @@ impl<T: Trait> Mutation<T> {
         actual_subed
     }
 
+    pub fn frozen(&mut self, who: &T::AccountId) -> T::Balance {
+        let balance = self.get_or_fetch_balance(who);
+        balance.frozen
+    }
+
     pub fn add_frozen(&mut self, who: &T::AccountId, increment: T::Balance) -> DispatchResult {
         let mut balance = self.get_or_fetch_balance(who);
         balance.frozen = balance

--- a/pallets/tokens/src/tests/adapter.rs
+++ b/pallets/tokens/src/tests/adapter.rs
@@ -19,8 +19,8 @@ use crate::Error;
 use frame_support::{
     assert_noop, assert_ok,
     traits::{
-        BalanceStatus, Currency, ExistenceRequirement, Imbalance, ReservableCurrency,
-        SignedImbalance, WithdrawReason,
+        BalanceStatus, Currency, ExistenceRequirement, Imbalance, LockableCurrency,
+        ReservableCurrency, SignedImbalance, WithdrawReason, WithdrawReasons,
     },
 };
 use governance_os_support::{
@@ -425,5 +425,116 @@ fn slash_reserved() {
             let (imbalance, unslashed) = TokensCurrencyAdapter::slash_reserved(&ALICE, 50);
             assert_eq!(imbalance.peek(), 25);
             assert_eq!(unslashed, 25);
+        })
+}
+
+#[test]
+fn set_lock() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            TokensCurrencyAdapter::set_lock(*b"testtest", &ALICE, 25, WithdrawReasons::all());
+            assert_eq!(
+                Tokens::get_currency_account(TEST_TOKEN_ID, &ALICE).frozen,
+                25
+            );
+        })
+}
+
+#[test]
+fn extend_lock() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            TokensCurrencyAdapter::set_lock(*b"testtest", &ALICE, 25, WithdrawReasons::all());
+            TokensCurrencyAdapter::extend_lock(*b"testtest", &ALICE, 30, WithdrawReasons::all());
+            assert_eq!(
+                Tokens::get_currency_account(TEST_TOKEN_ID, &ALICE).frozen,
+                30
+            );
+        })
+}
+
+#[test]
+fn remove_lock() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            TokensCurrencyAdapter::set_lock(*b"testtest", &ALICE, 25, WithdrawReasons::all());
+            TokensCurrencyAdapter::remove_lock(*b"testtest", &ALICE);
+            assert_eq!(
+                Tokens::get_currency_account(TEST_TOKEN_ID, &ALICE).frozen,
+                0
+            );
+        })
+}
+
+#[test]
+fn can_not_withdraw_locked_balance() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            TokensCurrencyAdapter::set_lock(*b"testtest", &ALICE, 25, WithdrawReasons::all());
+            assert_noop!(
+                TokensCurrencyAdapter::ensure_can_withdraw(&ALICE, 100, WithdrawReasons::all(), 0),
+                Error::<Test>::BalanceLockTriggered
+            );
+
+            let withdraw_result = TokensCurrencyAdapter::withdraw(
+                &ALICE,
+                100,
+                WithdrawReasons::all(),
+                ExistenceRequirement::AllowDeath,
+            );
+            assert!(withdraw_result.is_err());
+            assert_eq!(
+                TokensCurrencyAdapter::withdraw(
+                    &ALICE,
+                    100,
+                    WithdrawReasons::all(),
+                    ExistenceRequirement::AllowDeath
+                )
+                .err()
+                .unwrap(),
+                Error::<Test>::BalanceLockTriggered.into()
+            );
+        })
+}
+
+#[test]
+fn can_not_transfer_locked_balance() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            TokensCurrencyAdapter::set_lock(*b"testtest", &ALICE, 25, WithdrawReasons::all());
+            assert_noop!(
+                TokensCurrencyAdapter::transfer(
+                    &ALICE,
+                    &BOB,
+                    100,
+                    ExistenceRequirement::AllowDeath
+                ),
+                Error::<Test>::BalanceLockTriggered
+            );
+        })
+}
+
+#[test]
+fn can_not_reserve_locked_balance() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            TokensCurrencyAdapter::set_lock(*b"testtest", &ALICE, 25, WithdrawReasons::all());
+            assert_eq!(TokensCurrencyAdapter::can_reserve(&ALICE, 100), false);
+            assert_noop!(
+                TokensCurrencyAdapter::reserve(&ALICE, 100,),
+                Error::<Test>::BalanceLockTriggered
+            );
         })
 }

--- a/pallets/tokens/src/tests/currencies.rs
+++ b/pallets/tokens/src/tests/currencies.rs
@@ -308,3 +308,55 @@ fn ensure_can_withdraw_refuse_if_non_transferable_currency() {
         );
     })
 }
+
+#[test]
+fn creating_a_new_account_inc_system_ref() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_ok!(<Tokens as Currencies<AccountId>>::mint(
+            TEST_TOKEN_ID,
+            &ALICE,
+            100
+        ));
+        assert_ok!(<Tokens as Currencies<AccountId>>::transfer(
+            TEST_TOKEN_ID,
+            &ALICE,
+            &BOB,
+            50
+        ));
+
+        assert_eq!(frame_system::Module::<Test>::refs(&ALICE), 1);
+        assert_eq!(frame_system::Module::<Test>::refs(&BOB), 1);
+    });
+}
+
+#[test]
+fn deleting_an_account_dec_system_ref() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_ok!(<Tokens as Currencies<AccountId>>::mint(
+            TEST_TOKEN_ID,
+            &ALICE,
+            100
+        ));
+        assert_ok!(<Tokens as Currencies<AccountId>>::transfer(
+            TEST_TOKEN_ID,
+            &ALICE,
+            &BOB,
+            50
+        ));
+
+        assert_ok!(<Tokens as Currencies<AccountId>>::transfer(
+            TEST_TOKEN_ID,
+            &BOB,
+            &ALICE,
+            50
+        ));
+        assert_ok!(<Tokens as Currencies<AccountId>>::burn(
+            TEST_TOKEN_ID,
+            &ALICE,
+            100
+        ));
+
+        assert_eq!(frame_system::Module::<Test>::refs(&ALICE), 0);
+        assert_eq!(frame_system::Module::<Test>::refs(&BOB), 0);
+    });
+}

--- a/pallets/tokens/src/tests/currencies.rs
+++ b/pallets/tokens/src/tests/currencies.rs
@@ -492,6 +492,78 @@ fn set_lock_with_different_id_extend_frozen_balance_if_needed() {
 }
 
 #[test]
+fn extend_lock_increases_lock() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                30
+            ));
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::extend_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                60
+            ));
+
+            assert_eq!(
+                Tokens::get_currency_account(TEST_TOKEN_ID, &ALICE).frozen,
+                60
+            );
+        })
+}
+
+#[test]
+fn extend_lock_does_not_decrease_lock() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                30
+            ));
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::extend_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                20
+            ));
+
+            assert_eq!(
+                Tokens::get_currency_account(TEST_TOKEN_ID, &ALICE).frozen,
+                30
+            );
+        })
+}
+
+#[test]
+fn extend_lock_creates_new_lock_if_needed() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::extend_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                60
+            ));
+
+            assert_eq!(
+                Tokens::get_currency_account(TEST_TOKEN_ID, &ALICE).frozen,
+                60
+            );
+        })
+}
+
+#[test]
 fn can_not_withdraw_locked_balance() {
     ExtBuilder::default()
         .one_hundred_for_alice_n_bob()
@@ -574,3 +646,12 @@ fn can_not_burn_locked_balance() {
             );
         })
 }
+
+// #[test]
+// fn set_new_lock_inc_ref() {}
+
+// #[test]
+// fn extend_new_lock_inc_ref() {}
+
+// #[test]
+// fn remove_lock_dec_ref() {}

--- a/pallets/tokens/src/tests/currencies.rs
+++ b/pallets/tokens/src/tests/currencies.rs
@@ -736,11 +736,103 @@ fn can_not_burn_locked_balance() {
         })
 }
 
-// #[test]
-// fn set_new_lock_inc_ref() {}
+#[test]
+fn set_new_lock_inc_ref() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                60
+            ));
 
-// #[test]
-// fn extend_new_lock_inc_ref() {}
+            assert_eq!(frame_system::Module::<Test>::refs(&ALICE), 2);
+        })
+}
+#[test]
+fn set_existing_lock_does_not_inc_ref() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                60
+            ));
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                50
+            ));
 
-// #[test]
-// fn remove_lock_dec_ref() {}
+            assert_eq!(frame_system::Module::<Test>::refs(&ALICE), 2);
+        })
+}
+
+#[test]
+fn extend_new_lock_inc_ref() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::extend_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                60
+            ));
+
+            assert_eq!(frame_system::Module::<Test>::refs(&ALICE), 2);
+        })
+}
+
+#[test]
+fn extend_existing_lock_does_not_inc_ref() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                50
+            ));
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::extend_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                60
+            ));
+
+            assert_eq!(frame_system::Module::<Test>::refs(&ALICE), 2);
+        })
+}
+
+#[test]
+fn remove_lock_dec_ref() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                60
+            ));
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::remove_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+            ));
+
+            assert_eq!(frame_system::Module::<Test>::refs(&ALICE), 1);
+        })
+}

--- a/pallets/tokens/src/tests/currencies.rs
+++ b/pallets/tokens/src/tests/currencies.rs
@@ -22,7 +22,7 @@ use frame_support::{
 };
 use governance_os_support::{
     testing::{primitives::AccountId, ALICE, BOB, TEST_TOKEN_ID, TEST_TOKEN_OWNER},
-    traits::{Currencies, ReservableCurrencies},
+    traits::{Currencies, LockableCurrencies, ReservableCurrencies},
 };
 
 #[test]
@@ -359,4 +359,218 @@ fn deleting_an_account_dec_system_ref() {
         assert_eq!(frame_system::Module::<Test>::refs(&ALICE), 0);
         assert_eq!(frame_system::Module::<Test>::refs(&BOB), 0);
     });
+}
+
+#[test]
+fn set_lock_effectively_freeze_part_of_the_balance() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                30
+            ));
+            assert_eq!(
+                Tokens::get_currency_account(TEST_TOKEN_ID, &ALICE).frozen,
+                30
+            );
+            assert_noop!(
+                <Tokens as Currencies<AccountId>>::transfer(TEST_TOKEN_ID, &ALICE, &BOB, 100),
+                Error::<Test>::BalanceLockTriggered
+            );
+        })
+}
+
+#[test]
+fn set_lock_with_same_id_overwrite_existing_lock() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            // Initial setup
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                30
+            ));
+            assert_eq!(
+                Tokens::get_currency_account(TEST_TOKEN_ID, &ALICE).frozen,
+                30
+            );
+
+            // Reduce lock
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                20
+            ));
+            assert_eq!(
+                Tokens::get_currency_account(TEST_TOKEN_ID, &ALICE).frozen,
+                20
+            );
+
+            // Increase lock
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                40
+            ));
+            assert_eq!(
+                Tokens::get_currency_account(TEST_TOKEN_ID, &ALICE).frozen,
+                40
+            );
+        })
+}
+
+#[test]
+fn can_lock_more_than_free_balance() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                120
+            ));
+            assert_eq!(
+                Tokens::get_currency_account(TEST_TOKEN_ID, &ALICE).frozen,
+                120
+            );
+
+            // We locked more than free balance and thus can't transfer anything
+            assert_noop!(
+                <Tokens as Currencies<AccountId>>::transfer(TEST_TOKEN_ID, &ALICE, &BOB, 1),
+                Error::<Test>::BalanceLockTriggered
+            );
+        })
+}
+
+#[test]
+fn set_lock_with_different_id_extend_frozen_balance_if_needed() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                30
+            ));
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"deadbeef",
+                &ALICE,
+                30
+            ));
+            // No lock increase
+            assert_eq!(
+                Tokens::get_currency_account(TEST_TOKEN_ID, &ALICE).frozen,
+                30
+            );
+
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"deadbeef",
+                &ALICE,
+                50
+            ));
+            // Lock increase
+            assert_eq!(
+                Tokens::get_currency_account(TEST_TOKEN_ID, &ALICE).frozen,
+                50
+            );
+        })
+}
+
+#[test]
+fn can_not_withdraw_locked_balance() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                60
+            ));
+
+            assert_noop!(
+                <Tokens as Currencies<AccountId>>::ensure_can_withdraw(TEST_TOKEN_ID, &ALICE, 50),
+                Error::<Test>::BalanceLockTriggered
+            );
+        })
+}
+
+#[test]
+fn can_not_reserve_locked_balance() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                60
+            ));
+
+            assert_eq!(
+                <Tokens as ReservableCurrencies<AccountId>>::can_reserve(TEST_TOKEN_ID, &ALICE, 50),
+                false
+            );
+            assert_noop!(
+                <Tokens as ReservableCurrencies<AccountId>>::reserve(TEST_TOKEN_ID, &ALICE, 50),
+                Error::<Test>::BalanceLockTriggered
+            );
+        })
+}
+
+#[test]
+fn can_not_transfer_locked_balance() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                60
+            ));
+
+            assert_noop!(
+                <Tokens as Currencies<AccountId>>::transfer(TEST_TOKEN_ID, &ALICE, &BOB, 50),
+                Error::<Test>::BalanceLockTriggered
+            );
+        })
+}
+
+#[test]
+fn can_not_burn_locked_balance() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_ok!(<Tokens as LockableCurrencies<AccountId>>::set_lock(
+                TEST_TOKEN_ID,
+                *b"testtest",
+                &ALICE,
+                60
+            ));
+
+            assert_noop!(
+                <Tokens as Currencies<AccountId>>::burn(TEST_TOKEN_ID, &ALICE, 50),
+                Error::<Test>::BalanceLockTriggered
+            );
+        })
 }

--- a/pallets/tokens/src/tests/genesis.rs
+++ b/pallets/tokens/src/tests/genesis.rs
@@ -55,3 +55,13 @@ fn set_test_token_roles_approprietaly() {
         );
     })
 }
+
+#[test]
+fn new_account_is_created_with_system_ref() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            assert_eq!(frame_system::Module::<Test>::refs(&ALICE), 1);
+        })
+}

--- a/pallets/tokens/src/tests/mod.rs
+++ b/pallets/tokens/src/tests/mod.rs
@@ -20,3 +20,4 @@ mod dispatchable;
 mod genesis;
 mod misc;
 pub mod mock;
+mod mutations;

--- a/pallets/tokens/src/tests/mutations.rs
+++ b/pallets/tokens/src/tests/mutations.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Nuclei Studio OÜ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::mock::*;
+use crate::{mutations::Mutation, Error};
+use frame_support::{assert_noop, assert_ok};
+use governance_os_support::testing::{ALICE, TEST_TOKEN_ID};
+
+#[test]
+fn sub_up_to_free_balance_honors_frozen() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            let mut mutation = Mutation::<Test>::new_for_currency(TEST_TOKEN_ID);
+            assert_ok!(mutation.add_frozen(&ALICE, 40));
+            assert_eq!(mutation.sub_up_to_free_balance(&ALICE, 100), 60);
+        })
+}
+
+#[test]
+fn sub_free_balance_honors_frozen() {
+    ExtBuilder::default()
+        .one_hundred_for_alice_n_bob()
+        .build()
+        .execute_with(|| {
+            let mut mutation = Mutation::<Test>::new_for_currency(TEST_TOKEN_ID);
+            assert_ok!(mutation.add_frozen(&ALICE, 40));
+            assert_noop!(
+                mutation.sub_free_balance(&ALICE, 100),
+                Error::<Test>::BalanceLockTriggered
+            );
+        })
+}

--- a/support/src/traits.rs
+++ b/support/src/traits.rs
@@ -15,5 +15,5 @@
  */
 
 pub use crate::acl::RoleManager;
-pub use crate::currencies::{Currencies, ReservableCurrencies};
+pub use crate::currencies::{Currencies, LockableCurrencies, ReservableCurrencies};
 pub use crate::voting::VotingHooks;

--- a/types.json
+++ b/types.json
@@ -1,7 +1,8 @@
 {
   "AccountCurrencyData": {
     "free": "Balance",
-    "reserved": "Balance"
+    "reserved": "Balance",
+    "frozen": "Balance"
   },
   "AccountInfo": {
     "nonce": "Index",


### PR DESCRIPTION
Support currency locking with native and multi currency variants. Main caveat is that we ignore withdraw reasons as usual.

--


- add trait for lockable currencies
- increment and decrement system refs
- internal concept of frozen balances
- set_lock
- extend_lock
- removing locks
- update system refs when new locks are being added
- implement LockableCurrency for the NativeCurrency adapter
- incompatibility: slash reserved balance if needed
